### PR TITLE
Updated placeholders name in config

### DIFF
--- a/agents/base/crewai-websearch-agent/config.toml.example
+++ b/agents/base/crewai-websearch-agent/config.toml.example
@@ -18,7 +18,7 @@
   watsonx_url = ""
 
   # Deployment space id is required to create deployment with AI service content.
-  space_id = "PLACEHOLDER FOR YOUR SPACE ID"
+  space_id = "PLACEHOLDER_FOR_YOUR_SPACE_ID"
 
   # variable, that is populated with last created deployment_id every time when command `watsonx-ai service new` finish successfully
   deployment_id = ""
@@ -27,7 +27,7 @@
 # during creation of deployment additional parameters can be provided inside `CUSTOM` object for further referencing
 # please refer to the API docs: https://cloud.ibm.com/apidocs/machine-learning-cp#deployments-create
   model_id = "meta-llama/llama-3-3-70b-instruct"  # underlying model of WatsonxChat
-  project_id = "PLACEHOLDER FOR YOUR PROJECT ID" # needed for wx inference in litellm
+  project_id = "PLACEHOLDER_FOR_YOUR_PROJECT_ID" # needed for wx inference in litellm
   url = ""  # should follow the format: `https://{REGION}.ml.cloud.ibm.com`
 
 [deployment.software_specification]

--- a/agents/base/langgraph-react-agent/config.toml.example
+++ b/agents/base/langgraph-react-agent/config.toml.example
@@ -18,7 +18,7 @@
   watsonx_url = ""
 
   # Deployment space id is required to create deployment with AI service content.
-  space_id = "PLACEHOLDER FOR YOUR SPACE ID"
+  space_id = "PLACEHOLDER_FOR_YOUR_SPACE_ID"
 
   # variable, that is populated with last created deployment_id every time when command `watsonx-ai service new` finish successfully
   deployment_id = ""
@@ -28,7 +28,7 @@
 # please refer to the API docs: https://cloud.ibm.com/apidocs/machine-learning-cp#deployments-create
   model_id = "mistralai/mistral-large"  # underlying model of WatsonxChat
   thread_id = "thread-1" # More info here: https://langchain-ai.github.io/langgraph/how-tos/persistence/
-  space_id = "PLACEHOLDER FOR YOUR SPACE ID"
+  space_id = "PLACEHOLDER_FOR_YOUR_SPACE_ID"
   url = ""  # should follow the format: `https://{REGION}.ml.cloud.ibm.com`
 
 [deployment.software_specification]

--- a/agents/base/llamaindex-websearch-agent/config.toml.example
+++ b/agents/base/llamaindex-websearch-agent/config.toml.example
@@ -18,7 +18,7 @@
   watsonx_url = ""
 
   # Deployment space id is required to create deployment with AI service content.
-  space_id = "PLACEHOLDER FOR YOUR SPACE ID"
+  space_id = "PLACEHOLDER_FOR_YOUR_SPACE_ID"
 
   # variable, that is populated with last created deployment_id every time when command `watsonx-ai service new` finish successfully
   deployment_id = ""
@@ -27,7 +27,7 @@
 # during creation of deployment additional parameters can be provided inside `CUSTOM` object for further referencing
 # please refer to the API docs: https://cloud.ibm.com/apidocs/machine-learning-cp#deployments-create
   model_id = "mistralai/mistral-large"  # underlying model of WatsonxChat
-  space_id = "PLACEHOLDER FOR YOUR SPACE ID"
+  space_id = "PLACEHOLDER_FOR_YOUR_SPACE_ID"
   url = ""  # should follow the format: `https://{REGION}.ml.cloud.ibm.com`
 
 [deployment.software_specification]

--- a/agents/community/langgraph-arxiv-research/config.toml.example
+++ b/agents/community/langgraph-arxiv-research/config.toml.example
@@ -18,7 +18,7 @@
   watsonx_url = ""
 
   # Deployment space id is required to create deployment with AI service content.
-  space_id = "PLACEHOLDER FOR YOUR SPACE ID"
+  space_id = "PLACEHOLDER_FOR_YOUR_SPACE_ID"
 
   # variable, that is populated with last created deployment_id every time when command `watsonx-ai service new` finish successfully
   deployment_id = ""
@@ -28,7 +28,7 @@
 # please refer to the API docs: https://cloud.ibm.com/apidocs/machine-learning-cp#deployments-create
   model_id = "mistralai/mistral-large"  # underlying model of WatsonxChat
   thread_id = "thread-1" # More info here: https://langchain-ai.github.io/langgraph/how-tos/persistence/
-  space_id = "PLACEHOLDER FOR YOUR SPACE ID"
+  space_id = "PLACEHOLDER_FOR_YOUR_SPACE_ID"
   url = ""  # should follow the format: `https://{REGION}.ml.cloud.ibm.com`
 
 [deployment.software_specification]


### PR DESCRIPTION
For better user experience placeholder names should be separated by underscore instead of space