### PR TITLE
feat: Update base template's README to use ibm-watsonx-ai CLI instead of Python scripts

### DIFF
--- a/agents/base/autogen-agent/README.md
+++ b/agents/base/autogen-agent/README.md
@@ -13,7 +13,6 @@
 * [Querying the deployment](#-querying-the-deployment)  
 * [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)   
 
-
 ## 🤔 Introduction
 
 This repository provides a basic template for LLM apps built using AutoGen framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].

--- a/agents/base/autogen-agent/README.md
+++ b/agents/base/autogen-agent/README.md
@@ -1,102 +1,83 @@
-# An AutoGen template with function calling capabilities
+# An AutoGen template with function calling capabilities 🚀
 
-Table of contents:  
-* [Introduction](#introduction)  
-* [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  
-* [Prerequisites](#prerequisites)  
-* [Cloning and setting up the template](#cloning-and-setting-up-the-template)  
-* [Modifying and configuring the template](#modifying-and-configuring-the-template)  
-* [Running unit tests for the template](#running-unit-tests-for-the-template)  
-* [Running the application locally](#running-the-application-locally)  
-* [Deploying on Cloud](#deploying-on-ibm-cloud)  
-* [Querying the deployment](#querying-the-deployment)  
+## 📖 Table of Contents
+* [Introduction](#-introduction)  
+* [Directory structure and file descriptions](#-directory-structure-and-file-descriptions)  
+* [Prerequisites](#-prerequisites)  
+* [Installation](#-installation)
+* [Configuration](#%EF%B8%8F-configuration)  
+* [Modifying and configuring the template](#-modifying-and-configuring-the-template)  
+* [Testing the template](#-testing-the-template)  
+* [Running the application locally](#-running-the-application-locally)  
+* [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
+* [Querying the deployment](#-querying-the-deployment)  
+* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)   
 
 
-## Introduction  
+## 🤔 Introduction
 
-This repository provides a basic template for LLM apps built using AutoGen framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].  
-An AI service is a deployable unit of code that captures the logic of your generative AI use case. For and in-depth description of the topic please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).  
+This repository provides a basic template for LLM apps built using AutoGen framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
 
-[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.  
+An AI service is a deployable unit of code that encapsulates the logic of your generative AI use case. For an in-depth description of AI services, please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).
+
+[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.
+
+**Highlights:**
+
+* 🚀 Easy-to-extend agent and tool modules
+* ⚙️ Configurable via `config.toml`
+* 🌐 Step-by-step local and cloud deployment
 
 The template builds a simple application with external tool for addressing Dummy Web Search use case.   
 
-## Directory structure and file descriptions  
+## 🗂 Directory structure and file descriptions
 
 The high level structure of the repository is as follows:  
 
-autogen-agent  
- ┣ src  
- ┃ ┗ autogen_agent_base  
- ┃   ┣  \_\_init\_\_.py  
- ┃   ┣ agent.py  
- ┃   ┗ tools.py  
- ┣ schema  
- ┣ ai_service.py  
- ┣ config.toml.example  
- ┗ pyproject.toml  
-
-- `autogen_agent_base` folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
-- `schema` folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
-- `ai_service.py` file: Contains the function to be deployed as an AI service defining the application's logic  
-- `config.toml.example` file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case.
-
-## Prerequisites  
-
-- [Poetry](https://python-poetry.org/) package manager,  
-- [Pipx](https://github.com/pypa/pipx) due to Poetry's recommended [installation procedure](https://python-poetry.org/docs/#installation)  
-
-## Cloning and setting up the template locally  
-
-
-### Step 1: Clone the repository  
-
-In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
-
-```sh
-git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
-cd watsonx-developer-hub
-git sparse-checkout add agents/base/autogen_agent
-```  
-
-Move to the directory with the agent template:
-
-```sh
-cd agents/base/autogen-agent/
 ```
+autogen-agent/
+├── src/
+│   └── autogen_agent_base/
+│       ├── agent.py
+│       └── tools.py
+├── schema/
+├── ai_service.py
+├── config.toml.example
+└── pyproject.toml
+```
+
+* **`autogen_agent_base`** folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
+* **`schema`** folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
+* **`ai_service.py`** file: Contains the function to be deployed as an AI service defining the application's logic  
+* **`config.toml.example`** file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case.
+
+## 🛠 Prerequisites
+
+* **Python 3.11**
+* **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
+* IBM Cloud access and permissions
+
+## 📥 Installation
+
+To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
+
+```sh
+pip install -U ibm-watsonx-ai-cli
+```
+
+> [!WARNING]
+> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
+> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
 
 > [!NOTE]
-> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/autogen-agent`  
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
 
+## ⚙️ Configuration
 
-### Step 2: Install poetry  
+1. Copy `config.toml.example` → `config.toml`.
+2. Fill in IBM Cloud credentials.
 
-```sh
-pipx install --python 3.11 poetry
-```
-
-### Step 3: Install the template    
-
-Running the below commands will install the repository in a separate virtual environment  
-
-```sh
-poetry install
-```
-
-### Step 4 (OPTIONAL): Activate the virtual environment  
-
-```sh
-source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-```
-
-### Step 5: Export PYTHONPATH  
-
-Adding working directory to PYTHONPATH is necessary for the next steps. In your terminal execute:  
-```sh
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-```
-
-## Modifying and configuring the template  
+## 🎨 Modifying and configuring the template
 
 [config.toml](config.toml) file should be filled in before either deploying the template on IBM Cloud or executing it locally.  
 Possible config parameters are given in the provided file and explained using comments (when necessary).  
@@ -122,7 +103,7 @@ For a detailed breakdown of the ai-service's implementation please refer the [IB
 In order to add new tool create a new function and add to the `TOOLS` list in the `extensions` module's [__init__.py](src/autogen_agent_base/__init__.py)
 
 
-## Testing the template  
+## 🧪 Testing the template
 
 The `tests/` directory's structure resembles the repository. Adding new tests should follow this convention.  
 For exemplary purposes only the tools and some general utility functions are covered with unit tests.  
@@ -132,52 +113,150 @@ Running the below command will run the complete tests suite:
 pytest -r 'fEsxX' tests/
 ```  
 
-## Running the application locally  
+## 💻 Running the application locally
 
-It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.  
+It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.
 
-### Step 1: Fill in the `config` file  
+Ensure `config.toml` is configured.
 
-Enter the necessary credentials in the `config.toml` file.  
+You can test and debug your AI service locally via two alternative flows:
 
-### Step 2: Run the script for local AI service execution  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+
+1. **Install CLI**:
+
+   ```sh
+   pip install ibm-watsonx-ai-cli
+   ```
+
+2. **Invoke**:
+
+   ```sh
+   watsonx-ai template invoke "<PROMPT>"
+   ```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+1. **Run Python Script**:
+
+   ```sh
+   python examples/execute_ai_service_locally.py
+   ```
+
+2. **Ask the model**:
+
+   Choose from some pre-defined questions or ask the model your own.
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+## ☁️ Deploying on IBM Cloud
+
+Follow these steps to deploy the model on IBM Cloud. 
+
+Ensure `config.toml` is configured.
+
+You can deploy your AI service to IBM Cloud via two alternative flows:
+
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-poetry run python examples/execute_ai_service_locally.py
-```  
+watsonx-ai service new
+```
 
-### Step 3: Ask the model  
+*Config file updates automatically with `deployment_id`.*
 
-Choose from some pre-defined questions or ask the model your own.
-
-
-## Deploying on IBM Cloud  
-
-Follow these steps to deploy the model on IBM Cloud.  
-
-### Step 1: Fill in the `config` file  
-
-Enter the necessary credentials in the `config.toml` file.  
-
-### Step 2: Run the deployment script  
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 ```sh
 python scripts/deploy.py
-```  
+```
 
-Successfully completed script will print on stdout the `deployment_id` which is necessary to locally test the deployment. For further info please refer [to the next section](#querying-the-deployment)  
+*Script prints `deployment_id`; update `config.toml`.*
 
-## Querying the deployment  
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
 
-Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  
+## 🔍 Querying the deployment
 
-### Step 1: Initialize the deployment ID  
+You can send inference requests to your deployed AI service via two alternative flows:
 
-Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
-
-### Step 2: Run the script for querying the deployment  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/query_existing_deployment.py
-```   
+watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
+```
+
+*If `deployment_id` is set in `config.toml`, omit the flag.*
+
+```sh
+watsonx-ai service invoke "<PROMPT>"
+```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
+
+1. **Initialize the deployment ID**:
+
+   Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
+   The _deployment_id_ of your deployment can be obtained from [the previous section](#%EF%B8%8F-deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
+
+2. **Run the script for querying the deployment**:
+
+   ```sh
+   python examples/query_existing_deployment.py
+   ```
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+---
+
+**Enjoy your coding! 🚀**
+
+---
+
+## 💾 Cloning and setting up the template (Optional)
+
+1. **Clone the repo** (sparse checkout):
+
+   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+   
+   ```sh
+   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
+   cd watsonx-developer-hub
+   git sparse-checkout add agents/base/autogen_agent
+   cd agents/base/autogen_agent/
+   ```
+
+> [!NOTE]
+> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/autogen-agent`  
+
+2. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+3. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+4. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+5. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```

--- a/agents/base/autogen-agent/README.md
+++ b/agents/base/autogen-agent/README.md
@@ -11,7 +11,7 @@
 * [Running the application locally](#-running-the-application-locally)  
 * [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
 * [Querying the deployment](#-querying-the-deployment)  
-* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)   
+* [Cloning template (Optional)](#-cloning-template-optional)    
 
 ## 🤔 Introduction
 
@@ -60,16 +60,49 @@ autogen-agent/
 
 To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
-```sh
-pip install -U ibm-watsonx-ai-cli
-```
+1. **Install CLI**:
 
-> [!WARNING]
-> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
-> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
+   ```sh
+   pip install -U ibm-watsonx-ai-cli
+   ```
+
+2. **Download template**:
+   ```sh
+   watsonx-ai template new "base/autogen-agent"
+   ```
+
+   Upon executing the above command, a prompt will appear requesting the user to specify the target directory for downloading the template. Once the template has been successfully downloaded, navigate to the designated template folder to proceed.
 
 > [!NOTE]
-> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning template (Optional)](#-cloning-template-optional)".
+
+3. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+4. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+5. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+6. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```
 
 ## ⚙️ Configuration
 
@@ -120,21 +153,13 @@ Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
-1. **Install CLI**:
+```sh
+watsonx-ai template invoke "<PROMPT>"
+```
 
-   ```sh
-   pip install ibm-watsonx-ai-cli
-   ```
-
-2. **Invoke**:
-
-   ```sh
-   watsonx-ai template invoke "<PROMPT>"
-   ```
-
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 1. **Run Python Script**:
 
@@ -147,7 +172,7 @@ You can test and debug your AI service locally via two alternative flows:
    Choose from some pre-defined questions or ask the model your own.
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## ☁️ Deploying on IBM Cloud
 
@@ -157,7 +182,7 @@ Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service new
@@ -165,7 +190,7 @@ watsonx-ai service new
 
 *Config file updates automatically with `deployment_id`.*
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 ```sh
 python scripts/deploy.py
@@ -174,13 +199,13 @@ python scripts/deploy.py
 *Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
@@ -192,7 +217,7 @@ watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
 watsonx-ai service invoke "<PROMPT>"
 ```
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
 
@@ -208,7 +233,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
    ```
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ---
 
@@ -216,7 +241,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-## 💾 Cloning and setting up the template (Optional)
+## 💾 Cloning template (Optional)
 
 1. **Clone the repo** (sparse checkout):
 
@@ -231,31 +256,3 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 > [!NOTE]
 > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/autogen-agent`  
-
-2. **Install Poetry**:
-
-   ```sh
-   pipx install --python 3.11 poetry
-   ```
-
-3. **Install the template**:
-
-    Running the below commands will install the repository in a separate virtual environment
-   
-   ```sh
-   poetry install
-   ```
-
-4. **(Optional) Activate the virtual environment**:
-
-   ```sh
-   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-   ```
-
-5. **Export PYTHONPATH**:
-
-   Adding working directory to PYTHONPATH is necessary for the next steps.
-
-   ```sh
-   export PYTHONPATH=$(pwd):${PYTHONPATH}
-   ```

--- a/agents/base/beeai-framework-react-agent/README.md
+++ b/agents/base/beeai-framework-react-agent/README.md
@@ -1,104 +1,85 @@
-# A Base beeai-framework LLM app template with function calling capabilities  
+# A Base beeai-framework LLM app template with function calling capabilities 🚀
 
-Table of contents:  
-* [Introduction](#introduction)  
-* [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  
-* [Prerequisites](#prerequisites)  
-* [Cloning and setting up the template](#cloning-and-setting-up-the-template)  
-* [Modifying and configuring the template](#modifying-and-configuring-the-template)  
-* [Running unit tests for the template](#running-unit-tests-for-the-template)  
-* [Running the application locally](#running-the-application-locally)  
-* [Deploying on Cloud](#deploying-on-ibm-cloud)  
-* [Inferencing the deployment](#inferencing-the-deployment)  
+## 📖 Table of Contents
+* [Introduction](#-introduction)  
+* [Directory structure and file descriptions](#-directory-structure-and-file-descriptions)  
+* [Prerequisites](#-prerequisites)  
+* [Installation](#-installation)
+* [Configuration](#%EF%B8%8F-configuration)  
+* [Modifying and configuring the template](#-modifying-and-configuring-the-template)  
+* [Testing the template](#-testing-the-template)  
+* [Running the application locally](#-running-the-application-locally)  
+* [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
+* [Querying the deployment](#-querying-the-deployment)  
+* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
 
-## Introduction  
+## 🤔 Introduction
 
-This repository provides a basic template for LLM apps built using the beeai-framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].  
-An AI service is a deployable unit of code that captures the logic of your generative AI use case. For and in-depth description of the topic please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).  
+This repository provides a basic template for LLM apps built using the beeai-framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
 
-[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.  
+An AI service is a deployable unit of code that encapsulates the logic of your generative AI use case. For an in-depth description of AI services, please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).
+
+[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.
+
+**Highlights:**
+
+* 🚀 Easy-to-extend agent and tool modules
+* ⚙️ Configurable via `config.toml`
+* 🌐 Step-by-step local and cloud deployment
 
 The template builds a simple application with external tool for addressing Web Search Agent use case.
 
 Streaming version coming soon to this template.
 
-## Directory structure and file descriptions  
+## 🗂 Directory structure and file descriptions
 
 The high level structure of the repository is as follows:  
 
-beeai-framework-react-agent  
- ┣ src  
- ┃ ┗ beeai_framework_react_agent_base  
- ┃   ┣ agent.py  
- ┃   ┗ tools.py  
- ┣ schema  
- ┣ ai_service.py  
- ┣ config.toml.example  
- ┣ pyproject.toml  
-
-- `beeai_framework_react_agent_base` folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
-- `schema` folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
-- `ai_service.py` file: Contains the function to be deployed as an AI service defining the application's logic  
-- `config.toml.example` file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the config.toml.example file to the config.toml file and fill in the required fields. config.toml file can also be used to tweak the model for your use case.
-
-## Prerequisites  
-
-- [Poetry](https://python-poetry.org/) package manager,  
-- [Pipx](https://github.com/pypa/pipx) due to Poetry's recommended [installation procedure](https://python-poetry.org/docs/#installation)  
-
-
-## Cloning and setting up the template locally  
-
-
-### Step 1: Clone the repository  
-
-In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
-
-```sh
-git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
-cd watsonx-developer-hub
-git sparse-checkout add agents/base/beeai-framework-react-agent
-```  
-
-Move to the directory with the agent template:
-
-```sh
-cd agents/base/beeai-framework-react-agent/
 ```
+beeai-framework-react-agent/
+├── src/
+│   └── beeai_framework_react_agent_base/
+│       ├── agent.py
+│       └── tools.py
+├── schema/
+├── ai_service.py
+├── config.toml.example
+└── pyproject.toml
+```
+
+* **`beeai_framework_react_agent_base`** folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
+* **`schema`** folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
+* **`ai_service.py`** file: Contains the function to be deployed as an AI service defining the application's logic  
+* **`config.toml.example`** file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the config.toml.example file to the config.toml file and fill in the required fields. config.toml file can also be used to tweak the model for your use case.
+
+## 🛠 Prerequisites
+
+* **Python 3.11**
+* **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
+* IBM Cloud access and permissions
+
+## 📥 Installation
+
+To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
+
+```sh
+pip install -U ibm-watsonx-ai-cli
+```
+
+> [!WARNING]
+> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
+> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
 
 > [!NOTE]
-> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/beeai-framework-react-agent/`  
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
 
+## ⚙️ Configuration
 
-### Step 2: Install poetry  
+1. Copy `config.toml.example` → `config.toml`.
+2. Fill in IBM Cloud credentials.
 
-```sh
-pipx install --python 3.11 poetry
-```
-
-### Step 3: Install the template    
-
-Running the below commands will install the repository in a separate virtual environment  
-
-```sh
-poetry install
-```
-
-### Step 4 (OPTIONAL): Activate the virtual environment  
-
-```sh
-source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-```
-
-### Step 5: Export PYTHONPATH  
-
-Adding working directory to PYTHONPATH is necessary for the next steps. In your terminal execute:  
-```sh
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-```
-
-## Modifying and configuring the template  
+## 🎨 Modifying and configuring the template
 
 [config.toml](config.toml) file should be filled in before either deploying the template on IBM Cloud or executing it locally.  
 Possible config parameters are given in the provided file and explained using comments (when necessary).  
@@ -124,7 +105,7 @@ To add a new tool, create a class that extends the `beeai_framework.tools.tool` 
 
 For more sophisticated use cases, please refer to the [beeai-framework docs](https://github.com/i-am-bee/beeai-framework).  
 
-## Testing the template  
+## 🧪 Testing the template
 
 The `tests/` directory's structure resembles the repository. Adding new tests should follow this convention.  
 For exemplary purposes only the tools and some general utility functions are covered with unit tests.  
@@ -132,54 +113,153 @@ For exemplary purposes only the tools and some general utility functions are cov
 Running the below command will run the complete tests suite:
 ```sh
 pytest -r 'fEsxX' tests/
-```  
+```
 
-## Running the application locally  
+## 💻 Running the application locally
 
-It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.  
+It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.
 
-### Step 1: Fill in the `config` file  
+Ensure `config.toml` is configured.
 
-Enter the necessary credentials in the `config.toml` file.  
+You can test and debug your AI service locally via two alternative flows:
 
-### Step 2: Run the script for local AI service execution  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+
+1. **Install CLI**:
+
+   ```sh
+   pip install ibm-watsonx-ai-cli
+   ```
+
+2. **Invoke**:
+
+   ```sh
+   watsonx-ai template invoke "<PROMPT>"
+   ```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+1. **Run Python Script**:
+
+   ```sh
+   python examples/execute_ai_service_locally.py
+   ```
+
+2. **Ask the model**:
+
+   Choose from some pre-defined questions or ask the model your own.
+
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+## ☁️ Deploying on IBM Cloud
+
+Follow these steps to deploy the model on IBM Cloud. 
+
+Ensure `config.toml` is configured.
+
+You can deploy your AI service to IBM Cloud via two alternative flows:
+
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/execute_ai_service_locally.py
-```  
+watsonx-ai service new
+```
 
-### Step 3: Ask the model  
+*Config file updates automatically with `deployment_id`.*
 
-Choose from some pre-defined questions or ask the model your own.
-
-
-## Deploying on IBM Cloud  
-
-Follow these steps to deploy the model on IBM Cloud.  
-
-### Step 1: Fill in the `config` file  
-
-Enter the necessary credentials in the `config.toml` file.  
-
-### Step 2: Run the deployment script  
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 ```sh
 python scripts/deploy.py
-```  
+```
 
-Successfully completed script will print on stdout the `deployment_id` which is necessary to locally test the deployment. For further info please refer [to the next section](#querying-the-deployment)  
+*Script prints `deployment_id`; update `config.toml`.*
 
-## Querying the deployment  
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
 
-Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  
+## 🔍 Querying the deployment
 
-### Step 1: Initialize the deployment ID  
+You can send inference requests to your deployed AI service via two alternative flows:
 
-Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
-
-### Step 2: Run the script for querying the deployment  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/query_existing_deployment.py
-```   
+watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
+```
+
+*If `deployment_id` is set in `config.toml`, omit the flag.*
+
+```sh
+watsonx-ai service invoke "<PROMPT>"
+```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
+
+1. **Initialize the deployment ID**:
+
+   Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
+   The _deployment_id_ of your deployment can be obtained from [the previous section](#%EF%B8%8F-deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
+
+2. **Run the script for querying the deployment**:
+
+   ```sh
+   python examples/query_existing_deployment.py
+   ```
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+---
+
+**Enjoy your coding! 🚀**
+
+---
+
+## 💾 Cloning and setting up the template (Optional)
+
+1. **Clone the repo** (sparse checkout):
+
+   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+   
+   ```sh
+   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
+   cd watsonx-developer-hub
+   git sparse-checkout add agents/base/beeai-framework-react-agent
+   cd agents/base/beeai-framework-react-agent/
+   ```
+
+> [!NOTE]
+> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/beeai-framework-react-agent/`  
+
+2. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+3. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+4. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+5. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```

--- a/agents/base/beeai-framework-react-agent/README.md
+++ b/agents/base/beeai-framework-react-agent/README.md
@@ -11,7 +11,7 @@
 * [Running the application locally](#-running-the-application-locally)  
 * [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
 * [Querying the deployment](#-querying-the-deployment)  
-* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
+* [Cloning template (Optional)](#-cloning-template-optional)  
 
 ## 🤔 Introduction
 
@@ -62,16 +62,49 @@ beeai-framework-react-agent/
 
 To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
-```sh
-pip install -U ibm-watsonx-ai-cli
-```
+1. **Install CLI**:
 
-> [!WARNING]
-> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
-> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
+   ```sh
+   pip install -U ibm-watsonx-ai-cli
+   ```
+
+2. **Download template**:
+   ```sh
+   watsonx-ai template new "base/beeai-framework-react-agent"
+   ```
+
+   Upon executing the above command, a prompt will appear requesting the user to specify the target directory for downloading the template. Once the template has been successfully downloaded, navigate to the designated template folder to proceed.
 
 > [!NOTE]
-> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning template (Optional)](#-cloning-template-optional)".
+
+3. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+4. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+5. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+6. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```
 
 ## ⚙️ Configuration
 
@@ -122,21 +155,13 @@ Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
-1. **Install CLI**:
+```sh
+watsonx-ai template invoke "<PROMPT>"
+```
 
-   ```sh
-   pip install ibm-watsonx-ai-cli
-   ```
-
-2. **Invoke**:
-
-   ```sh
-   watsonx-ai template invoke "<PROMPT>"
-   ```
-
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 1. **Run Python Script**:
 
@@ -149,7 +174,7 @@ You can test and debug your AI service locally via two alternative flows:
    Choose from some pre-defined questions or ask the model your own.
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## ☁️ Deploying on IBM Cloud
 
@@ -159,7 +184,7 @@ Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service new
@@ -167,7 +192,7 @@ watsonx-ai service new
 
 *Config file updates automatically with `deployment_id`.*
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 ```sh
 python scripts/deploy.py
@@ -176,13 +201,13 @@ python scripts/deploy.py
 *Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
@@ -194,7 +219,7 @@ watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
 watsonx-ai service invoke "<PROMPT>"
 ```
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
 
@@ -210,7 +235,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
    ```
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ---
 
@@ -218,7 +243,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-## 💾 Cloning and setting up the template (Optional)
+## 💾 Cloning template (Optional)
 
 1. **Clone the repo** (sparse checkout):
 
@@ -233,31 +258,3 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 > [!NOTE]
 > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/beeai-framework-react-agent/`  
-
-2. **Install Poetry**:
-
-   ```sh
-   pipx install --python 3.11 poetry
-   ```
-
-3. **Install the template**:
-
-    Running the below commands will install the repository in a separate virtual environment
-   
-   ```sh
-   poetry install
-   ```
-
-4. **(Optional) Activate the virtual environment**:
-
-   ```sh
-   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-   ```
-
-5. **Export PYTHONPATH**:
-
-   Adding working directory to PYTHONPATH is necessary for the next steps.
-
-   ```sh
-   export PYTHONPATH=$(pwd):${PYTHONPATH}
-   ```

--- a/agents/base/beeai-framework-react-agent/README.md
+++ b/agents/base/beeai-framework-react-agent/README.md
@@ -13,7 +13,6 @@
 * [Querying the deployment](#-querying-the-deployment)  
 * [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
-
 ## 🤔 Introduction
 
 This repository provides a basic template for LLM apps built using the beeai-framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
@@ -148,7 +147,6 @@ You can test and debug your AI service locally via two alternative flows:
 2. **Ask the model**:
 
    Choose from some pre-defined questions or ask the model your own.
-
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.

--- a/agents/base/beeai-framework-workflow/README.md
+++ b/agents/base/beeai-framework-workflow/README.md
@@ -1,103 +1,83 @@
-# A Base beeai-framework LLM app template with function calling capabilities  
+# A Base beeai-framework LLM app template with function calling capabilities 🚀
 
-Table of contents:  
-* [Introduction](#introduction)  
-* [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  
-* [Prerequisites](#prerequisites)  
-* [Cloning and setting up the template](#cloning-and-setting-up-the-template)  
-* [Modifying and configuring the template](#modifying-and-configuring-the-template)  
-* [Running unit tests for the template](#running-unit-tests-for-the-template)  
-* [Running the application locally](#running-the-application-locally)  
-* [Deploying on Cloud](#deploying-on-ibm-cloud)  
-* [Inferencing the deployment](#inferencing-the-deployment)  
+## 📖 Table of Contents
+* [Introduction](#-introduction)  
+* [Directory structure and file descriptions](#-directory-structure-and-file-descriptions)  
+* [Prerequisites](#-prerequisites)  
+* [Installation](#-installation)
+* [Configuration](#%EF%B8%8F-configuration)  
+* [Modifying and configuring the template](#-modifying-and-configuring-the-template)  
+* [Running the application locally](#-running-the-application-locally)  
+* [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
+* [Querying the deployment](#-querying-the-deployment)  
+* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
 
-## Introduction  
+## 🤔 Introduction
 
-This repository provides a basic template for LLM apps built using the beeai-framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].  
-An AI service is a deployable unit of code that captures the logic of your generative AI use case. For and in-depth description of the topic please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).  
+This repository provides a basic template for LLM apps built using the beeai-framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
 
-[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.  
+An AI service is a deployable unit of code that encapsulates the logic of your generative AI use case. For an in-depth description of AI services, please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).
+
+[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.
 
 The template builds a simple multi agent workflow use case.
 
 Streaming version coming soon to this template.
 
-## Directory structure and file descriptions  
+**Highlights:**
+
+* 🚀 Easy-to-extend agent and tool modules
+* ⚙️ Configurable via `config.toml`
+* 🌐 Step-by-step local and cloud deployment
+
+## 🗂 Directory structure and file descriptions
 
 The high level structure of the repository is as follows:  
 
-beeai-framework-workflow  
- ┣ src  
- ┃ ┗ beeai_framework_workflow_base  
- ┃   ┣ workflow.py  
- ┣ schema  
- ┣ ai_service.py  
- ┣ config.toml.example  
- ┣ pyproject.toml  
-
-- `beeai_framework_workflow_base` folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
-- `schema` folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
-- `ai_service.py` file: Contains the function to be deployed as an AI service defining the application's logic  
-- `config.toml.example` file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the config.toml.example file to the config.toml file and fill in the required fields. config.toml file can also be used to tweak the model for your use case.
-
-## Prerequisites  
-
-- [Poetry](https://python-poetry.org/) package manager,  
-- [Pipx](https://github.com/pypa/pipx) due to Poetry's recommended [installation procedure](https://python-poetry.org/docs/#installation)  
-
-
-## Cloning and setting up the template locally  
-
-
-### Step 1: Clone the repository  
-
-In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
-
-```sh
-git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
-cd watsonx-developer-hub
-git sparse-checkout add agents/base/beeai-framework-workflow
-```  
-
-Move to the directory with the agent template:
-
-```sh
-cd agents/base/beeai-framework-workflow/
 ```
+beeai-framework-workflow/
+├── src/
+│   └── beeai_framework_workflow_base/
+│       └── workflow.py
+├── schema/
+├── ai_service.py
+├── config.toml.example
+└── pyproject.toml
+```
+
+* **`beeai_framework_workflow_base`** folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
+* **`schema`** folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
+* **`ai_service.py`** file: Contains the function to be deployed as an AI service defining the application's logic  
+* **`config.toml.example`** file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the config.toml.example file to the config.toml file and fill in the required fields. config.toml file can also be used to tweak the model for your use case.
+
+## 🛠 Prerequisites
+
+* **Python 3.11**
+* **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
+* IBM Cloud access and permissions
+
+## 📥 Installation
+
+To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
+
+```sh
+pip install -U ibm-watsonx-ai-cli
+```
+
+> [!WARNING]
+> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
+> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
 
 > [!NOTE]
-> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/beeai-framework-workflow/`  
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
 
+## ⚙️ Configuration
 
-### Step 2: Install poetry  
+1. Copy `config.toml.example` → `config.toml`.
+2. Fill in IBM Cloud credentials.
 
-```sh
-pipx install --python 3.11 poetry
-```
-
-### Step 3: Install the template    
-
-Running the below commands will install the repository in a separate virtual environment  
-
-```sh
-poetry install --with dev
-```
-
-### Step 4 (OPTIONAL): Activate the virtual environment  
-
-```sh
-source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-```
-
-### Step 5: Export PYTHONPATH  
-
-Adding working directory to PYTHONPATH is necessary for the next steps. In your terminal execute:  
-```sh
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-```
-
-## Modifying and configuring the template  
+## 🎨 Modifying and configuring the template
 
 [config.toml](config.toml) file should be filled in before either deploying the template on IBM Cloud or executing it locally.  
 Possible config parameters are given in the provided file and explained using comments (when necessary).  
@@ -119,52 +99,151 @@ For a detailed breakdown of the ai-service's implementation please refer the [IB
 
 For more sophisticated use cases, please refer to the [beeai-framework docs](https://github.com/i-am-bee/beeai-framework).  
 
-## Running the application locally  
+## 💻 Running the application locally
 
-It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.  
+It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.
 
-### Step 1: Fill in the `config` file  
+Ensure `config.toml` is configured.
 
-Enter the necessary credentials in the `config.toml` file.  
+You can test and debug your AI service locally via two alternative flows:
 
-### Step 2: Run the script for local AI service execution  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+
+1. **Install CLI**:
+
+   ```sh
+   pip install ibm-watsonx-ai-cli
+   ```
+
+2. **Invoke**:
+
+   ```sh
+   watsonx-ai template invoke "<PROMPT>"
+   ```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+1. **Run Python Script**:
+
+   ```sh
+   python examples/execute_ai_service_locally.py
+   ```
+
+2. **Ask the model**:
+
+   Choose from some pre-defined questions or ask the model your own.
+
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+## ☁️ Deploying on IBM Cloud
+
+Follow these steps to deploy the model on IBM Cloud. 
+
+Ensure `config.toml` is configured.
+
+You can deploy your AI service to IBM Cloud via two alternative flows:
+
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/execute_ai_service_locally.py
-```  
+watsonx-ai service new
+```
 
-### Step 3: Ask the model  
+*Config file updates automatically with `deployment_id`.*
 
-Choose from some pre-defined location or enter one of your own.
-
-
-## Deploying on IBM Cloud  
-
-Follow these steps to deploy the model on IBM Cloud.  
-
-### Step 1: Fill in the `config` file  
-
-Enter the necessary credentials in the `config.toml` file.  
-
-### Step 2: Run the deployment script  
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 ```sh
 python scripts/deploy.py
-```  
+```
 
-Successfully completed script will print on stdout the `deployment_id` which is necessary to locally test the deployment. For further info please refer [to the next section](#querying-the-deployment)  
+*Script prints `deployment_id`; update `config.toml`.*
 
-## Querying the deployment  
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
 
-Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  
+## 🔍 Querying the deployment
 
-### Step 1: Initialize the deployment ID  
+You can send inference requests to your deployed AI service via two alternative flows:
 
-Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
-
-### Step 2: Run the script for querying the deployment  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/query_existing_deployment.py
-```   
+watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
+```
+
+*If `deployment_id` is set in `config.toml`, omit the flag.*
+
+```sh
+watsonx-ai service invoke "<PROMPT>"
+```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
+
+1. **Initialize the deployment ID**:
+
+   Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
+   The _deployment_id_ of your deployment can be obtained from [the previous section](#%EF%B8%8F-deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
+
+2. **Run the script for querying the deployment**:
+
+   ```sh
+   python examples/query_existing_deployment.py
+   ```
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+---
+
+**Enjoy your coding! 🚀**
+
+---
+
+## 💾 Cloning and setting up the template (Optional)
+
+1. **Clone the repo** (sparse checkout):
+
+   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+   
+   ```sh
+   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
+   cd watsonx-developer-hub
+   git sparse-checkout add agents/base/beeai-framework-workflow
+   cd agents/base/beeai-framework-workflow/
+   ```
+
+> [!NOTE]
+> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/beeai-framework-workflow/`  
+
+2. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+3. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+4. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+5. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```

--- a/agents/base/beeai-framework-workflow/README.md
+++ b/agents/base/beeai-framework-workflow/README.md
@@ -10,7 +10,7 @@
 * [Running the application locally](#-running-the-application-locally)  
 * [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
 * [Querying the deployment](#-querying-the-deployment)  
-* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
+* [Cloning template (Optional)](#-cloning-template-optional)  
 
 ## 🤔 Introduction
 
@@ -60,16 +60,49 @@ beeai-framework-workflow/
 
 To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
-```sh
-pip install -U ibm-watsonx-ai-cli
-```
+1. **Install CLI**:
 
-> [!WARNING]
-> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
-> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
+   ```sh
+   pip install -U ibm-watsonx-ai-cli
+   ```
+
+2. **Download template**:
+   ```sh
+   watsonx-ai template new "base/beeai-framework-workflow"
+   ```
+
+   Upon executing the above command, a prompt will appear requesting the user to specify the target directory for downloading the template. Once the template has been successfully downloaded, navigate to the designated template folder to proceed.
 
 > [!NOTE]
-> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning template (Optional)](#-cloning-template-optional)".
+
+3. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+4. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+5. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+6. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```
 
 ## ⚙️ Configuration
 
@@ -106,21 +139,13 @@ Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
-1. **Install CLI**:
+```sh
+watsonx-ai template invoke "<PROMPT>"
+```
 
-   ```sh
-   pip install ibm-watsonx-ai-cli
-   ```
-
-2. **Invoke**:
-
-   ```sh
-   watsonx-ai template invoke "<PROMPT>"
-   ```
-
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 1. **Run Python Script**:
 
@@ -133,7 +158,7 @@ You can test and debug your AI service locally via two alternative flows:
    Choose from some pre-defined questions or ask the model your own.
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## ☁️ Deploying on IBM Cloud
 
@@ -143,7 +168,7 @@ Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service new
@@ -151,7 +176,7 @@ watsonx-ai service new
 
 *Config file updates automatically with `deployment_id`.*
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 ```sh
 python scripts/deploy.py
@@ -160,13 +185,13 @@ python scripts/deploy.py
 *Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
@@ -178,7 +203,7 @@ watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
 watsonx-ai service invoke "<PROMPT>"
 ```
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
 
@@ -194,7 +219,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
    ```
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ---
 
@@ -202,7 +227,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-## 💾 Cloning and setting up the template (Optional)
+## 💾 Cloning template (Optional)
 
 1. **Clone the repo** (sparse checkout):
 
@@ -217,31 +242,3 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 > [!NOTE]
 > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/beeai-framework-workflow/`  
-
-2. **Install Poetry**:
-
-   ```sh
-   pipx install --python 3.11 poetry
-   ```
-
-3. **Install the template**:
-
-    Running the below commands will install the repository in a separate virtual environment
-   
-   ```sh
-   poetry install
-   ```
-
-4. **(Optional) Activate the virtual environment**:
-
-   ```sh
-   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-   ```
-
-5. **Export PYTHONPATH**:
-
-   Adding working directory to PYTHONPATH is necessary for the next steps.
-
-   ```sh
-   export PYTHONPATH=$(pwd):${PYTHONPATH}
-   ```

--- a/agents/base/beeai-framework-workflow/README.md
+++ b/agents/base/beeai-framework-workflow/README.md
@@ -12,7 +12,6 @@
 * [Querying the deployment](#-querying-the-deployment)  
 * [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
-
 ## 🤔 Introduction
 
 This repository provides a basic template for LLM apps built using the beeai-framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
@@ -132,7 +131,6 @@ You can test and debug your AI service locally via two alternative flows:
 2. **Ask the model**:
 
    Choose from some pre-defined questions or ask the model your own.
-
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.

--- a/agents/base/crewai-websearch-agent/README.md
+++ b/agents/base/crewai-websearch-agent/README.md
@@ -11,7 +11,7 @@
 * [Running the application locally](#-running-the-application-locally)  
 * [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
 * [Querying the deployment](#-querying-the-deployment)  
-* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
+* [Cloning template (Optional)](#-cloning-template-optional)  
 
 ## 🤔 Introduction
 
@@ -59,16 +59,49 @@ crewai-websearch-agent/
 
 To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
-```sh
-pip install -U ibm-watsonx-ai-cli
-```
+1. **Install CLI**:
 
-> [!WARNING]
-> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
-> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
+   ```sh
+   pip install -U ibm-watsonx-ai-cli
+   ```
+
+2. **Download template**:
+   ```sh
+   watsonx-ai template new "base/crewai-websearch-agent"
+   ```
+
+   Upon executing the above command, a prompt will appear requesting the user to specify the target directory for downloading the template. Once the template has been successfully downloaded, navigate to the designated template folder to proceed.
 
 > [!NOTE]
-> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning template (Optional)](#-cloning-template-optional)".
+
+3. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+4. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+5. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+6. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```
 
 ## ⚙️ Configuration
 
@@ -117,21 +150,13 @@ Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
-1. **Install CLI**:
+```sh
+watsonx-ai template invoke "<PROMPT>"
+```
 
-   ```sh
-   pip install ibm-watsonx-ai-cli
-   ```
-
-2. **Invoke**:
-
-   ```sh
-   watsonx-ai template invoke "<PROMPT>"
-   ```
-
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 1. **Run Python Script**:
 
@@ -144,7 +169,7 @@ You can test and debug your AI service locally via two alternative flows:
    Choose from some pre-defined questions or ask the model your own.
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## ☁️ Deploying on IBM Cloud
 
@@ -154,7 +179,7 @@ Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service new
@@ -162,7 +187,7 @@ watsonx-ai service new
 
 *Config file updates automatically with `deployment_id`.*
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 ```sh
 python scripts/deploy.py
@@ -171,13 +196,13 @@ python scripts/deploy.py
 *Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
@@ -189,7 +214,7 @@ watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
 watsonx-ai service invoke "<PROMPT>"
 ```
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
 
@@ -205,7 +230,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
    ```
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ---
 
@@ -213,7 +238,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-## 💾 Cloning and setting up the template (Optional)
+## 💾 Cloning template (Optional)
 
 1. **Clone the repo** (sparse checkout):
 
@@ -228,31 +253,3 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 > [!NOTE]
 > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/crewai-websearch-agent`  
-
-2. **Install Poetry**:
-
-   ```sh
-   pipx install --python 3.11 poetry
-   ```
-
-3. **Install the template**:
-
-    Running the below commands will install the repository in a separate virtual environment
-   
-   ```sh
-   poetry install
-   ```
-
-4. **(Optional) Activate the virtual environment**:
-
-   ```sh
-   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-   ```
-
-5. **Export PYTHONPATH**:
-
-   Adding working directory to PYTHONPATH is necessary for the next steps.
-
-   ```sh
-   export PYTHONPATH=$(pwd):${PYTHONPATH}
-   ```

--- a/agents/base/crewai-websearch-agent/README.md
+++ b/agents/base/crewai-websearch-agent/README.md
@@ -1,98 +1,82 @@
-# A Base CrewAI LLM app template with function calling capabilities  
+# A Base CrewAI LLM app template with function calling capabilities 🚀
 
-Table of contents:  
-* [Introduction](#introduction)  
-* [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  
-* [Prerequisites](#prerequisites)  
-* [Cloning and setting up the template](#cloning-and-setting-up-the-template)  
-* [Modifying and configuring the template](#modifying-and-configuring-the-template)  
-* [Running unit tests for the template](#running-unit-tests-for-the-template)  
-* [Running the application locally](#running-the-application-locally)  
-* [Deploying on Cloud](#deploying-on-ibm-cloud)  
-* [Inferencing the deployment](#inferencing-the-deployment)  
+## 📖 Table of Contents
+* [Introduction](#-introduction)  
+* [Directory structure and file descriptions](#-directory-structure-and-file-descriptions)  
+* [Prerequisites](#-prerequisites)  
+* [Installation](#-installation)
+* [Configuration](#%EF%B8%8F-configuration)  
+* [Modifying and configuring the template](#-modifying-and-configuring-the-template)  
+* [Testing the template](#-testing-the-template)  
+* [Running the application locally](#-running-the-application-locally)  
+* [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
+* [Querying the deployment](#-querying-the-deployment)  
+* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
 
-## Introduction  
+## 🤔 Introduction
 
-This repository provides a basic template for LLM apps built using CrewAI framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].  
-An AI service is a deployable unit of code that captures the logic of your generative AI use case. For and in-depth description of the topic please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).  
+This repository provides a basic template for LLM apps built using CrewAI framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
 
-[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.  
+An AI service is a deployable unit of code that encapsulates the logic of your generative AI use case. For an in-depth description of AI services, please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).
 
-The template builds a simple application with external tool for addressing Web Search Agent use case.  
+[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.
 
-## Directory structure and file descriptions  
+**Highlights:**
+
+* 🚀 Easy-to-extend agent and tool modules
+* ⚙️ Configurable via `config.toml`
+* 🌐 Step-by-step local and cloud deployment
+
+## 🗂 Directory structure and file descriptions
 
 The high level structure of the repository is as follows:  
 
-crewai-websearch-agent  
- ┣ src  
- ┃ ┗ crewai_web_search    
- ┃     ┣ config  
- ┃     ┣ tools  
- ┃     ┣ \_\_init\_\_.py  
- ┃     ┗ crew.py  
- ┣ schema  
- ┣ ai_service.py  
- ┣ config.toml.example  
- ┗ pyproject.toml  
+```
+crewai-websearch-agent/
+├── src/
+│   └── crewai_web_search/
+│       ├── crew.py
+│       ├── tools/
+│       └── config/
+├── schema/
+├── ai_service.py
+├── config.toml.example
+└── pyproject.toml
+```
 
-- `crewai_web_search` folder: Contains CrewAI agents configuration yaml files (`src/crewai_web_search/config`) and auxiliary files used by the deployed function. These files provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
-- `schema` folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
-- `ai_service.py` file: Contains the function to be deployed as an AI service defining the application's logic  
-- `config.toml.example` file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case.
+* **`crewai_web_search`** folder: Contains CrewAI agents configuration yaml files (`src/crewai_web_search/config`) and auxiliary files used by the deployed function. These files provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
+* **`schema`** folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
+* **`ai_service.py`** file: Contains the function to be deployed as an AI service defining the application's logic  
+* **`config.toml.example`** file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case.
 
-## Prerequisites  
+## 🛠 Prerequisites
 
-- [Poetry](https://python-poetry.org/) package manager,  
-- [Pipx](https://github.com/pypa/pipx) due to Poetry's recommended [installation procedure](https://python-poetry.org/docs/#installation)  
+* **Python 3.11**
+* **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
+* IBM Cloud access and permissions 
 
+## 📥 Installation
 
-## Cloning and setting up the template locally  
-
-
-### Step 1: Clone the repository  
-
-In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
 ```sh
-git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
-cd watsonx-developer-hub
-git sparse-checkout add agents/crewai
-```  
+pip install -U ibm-watsonx-ai-cli
+```
+
+> [!WARNING]
+> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
+> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
 
 > [!NOTE]
-> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/crewai`  
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
 
+## ⚙️ Configuration
 
-### Step 2: Install poetry  
+1. Copy `config.toml.example` → `config.toml`.
+2. Fill in IBM Cloud credentials.
 
-```sh
-pipx install --python 3.11 poetry
-```
-
-### Step 3: Install the template    
-
-Running the below commands will install the repository in a separate virtual environment  
-
-```sh
-poetry install
-```
-
-### Step 4 (OPTIONAL): Activate the virtual environment  
-
-```sh
-source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-```
-
-### Step 5: Export PYTHONPATH  
-
-Adding working directory to PYTHONPATH is necessary for the next steps. In your terminal execute:  
-```sh
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-```
-
-## Modifying and configuring the template  
+## 🎨 Modifying and configuring the template 
 
 [config.toml](config.toml) file should be filled in before either deploying the template on IBM Cloud or executing it locally.  
 Possible config parameters are given in the provided file and explained using comments (when necessary).  
@@ -116,7 +100,7 @@ For a detailed breakdown of the ai-service's implementation please refer the [IB
 [tools.py](src/crewai_web_search/tools/tools.py) file stores the definition for tools enhancing the chat model's capabilities.  
 To add a new tool, create a class that extends the `crewai.tools.BaseTool` base class and has a `_run` method defined.
 
-## Testing the template  
+## 🧪 Testing the template
 
 The `tests/` directory's structure resembles the repository. Adding new tests should follow this convention.  
 For exemplary purposes only the tools and some general utility functions are covered with unit tests.  
@@ -126,52 +110,151 @@ Running the below command will run the complete tests suite:
 pytest -r 'fEsxX' tests/
 ```  
 
-## Running the application locally  
+## 💻 Running the application locally
 
-It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.  
+It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.
 
-### Step 1: Fill in the `config` file  
+Ensure `config.toml` is configured.
 
-Enter the necessary credentials in the `config.toml` file.  
+You can test and debug your AI service locally via two alternative flows:
 
-### Step 2: Run the script for local AI service execution  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+
+1. **Install CLI**:
+
+   ```sh
+   pip install ibm-watsonx-ai-cli
+   ```
+
+2. **Invoke**:
+
+   ```sh
+   watsonx-ai template invoke "<PROMPT>"
+   ```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+1. **Run Python Script**:
+
+   ```sh
+   python examples/execute_ai_service_locally.py
+   ```
+
+2. **Ask the model**:
+
+   Choose from some pre-defined questions or ask the model your own.
+
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+## ☁️ Deploying on IBM Cloud
+
+Follow these steps to deploy the model on IBM Cloud. 
+
+Ensure `config.toml` is configured.
+
+You can deploy your AI service to IBM Cloud via two alternative flows:
+
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/execute_ai_service_locally.py
-```  
+watsonx-ai service new
+```
 
-### Step 3: Ask the model  
+*Config file updates automatically with `deployment_id`.*
 
-Choose from some pre-defined questions or ask the model your own.
-
-
-## Deploying on IBM Cloud  
-
-Follow these steps to deploy the model on IBM Cloud.  
-
-### Step 1: Fill in the `config` file  
-
-Enter the necessary credentials in the `config.toml` file.  
-
-### Step 2: Run the deployment script  
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 ```sh
 python scripts/deploy.py
-```  
+```
 
-Successfully completed script will print on stdout the `deployment_id` which is necessary to locally test the deployment. For further info please refer [to the next section](#querying-the-deployment)  
+*Script prints `deployment_id`; update `config.toml`.*
 
-## Querying the deployment  
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
 
-Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  
+## 🔍 Querying the deployment
 
-### Step 1: Initialize the deployment ID  
+You can send inference requests to your deployed AI service via two alternative flows:
 
-Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
-
-### Step 2: Run the script for querying the deployment  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/query_existing_deployment.py
-```   
+watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
+```
+
+*If `deployment_id` is set in `config.toml`, omit the flag.*
+
+```sh
+watsonx-ai service invoke "<PROMPT>"
+```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
+
+1. **Initialize the deployment ID**:
+
+   Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
+   The _deployment_id_ of your deployment can be obtained from [the previous section](#%EF%B8%8F-deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
+
+2. **Run the script for querying the deployment**:
+
+   ```sh
+   python examples/query_existing_deployment.py
+   ```
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+---
+
+**Enjoy your coding! 🚀**
+
+---
+
+## 💾 Cloning and setting up the template (Optional)
+
+1. **Clone the repo** (sparse checkout):
+
+   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+   
+   ```sh
+   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
+   cd watsonx-developer-hub
+   git sparse-checkout add agents/base/crewai-websearch-agent
+   cd agents/base/crewai-websearch-agent/
+   ```
+
+> [!NOTE]
+> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/crewai-websearch-agent`  
+
+2. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+3. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+4. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+5. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```

--- a/agents/base/crewai-websearch-agent/README.md
+++ b/agents/base/crewai-websearch-agent/README.md
@@ -13,7 +13,6 @@
 * [Querying the deployment](#-querying-the-deployment)  
 * [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
-
 ## 🤔 Introduction
 
 This repository provides a basic template for LLM apps built using CrewAI framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
@@ -143,7 +142,6 @@ You can test and debug your AI service locally via two alternative flows:
 2. **Ask the model**:
 
    Choose from some pre-defined questions or ask the model your own.
-
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -36,12 +36,12 @@ The high level structure of the repository is as follows:
 langgraph-react-agent/
 ├── src/
 │   └── langgraph_react_agent_base/
-│       ├── agent.py      # Core graph and agent logic
-│       └── tools.py      # Custom tool definitions
-├── schema/               # JSON schemas for requests & responses
-├── ai_service.py         # Main AI service entry point
-├── config.toml.example   # Sample settings file
-└── pyproject.toml        # Poetry configuration
+│       ├── agent.py
+│       └── tools.py
+├── schema/
+├── ai_service.py
+├── config.toml.example
+└── pyproject.toml
 ```
 
 * **`langgraph-react-agent-base`** folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -13,7 +13,6 @@
 * [Querying the deployment](#-querying-the-deployment)  
 * [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
-
 ## 🤔 Introduction
 
 This repository provides a basic template for LLM apps built using the LangGraph framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
@@ -144,7 +143,6 @@ You can test and debug your AI service locally via two alternative flows:
 2. **Ask the model**:
 
    Choose from some pre-defined questions or ask the model your own.
-
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -147,7 +147,7 @@ Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-### Option A: CLI (Recommended)
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 1. **Install CLI**:
 
@@ -161,7 +161,7 @@ You can test and debug your AI service locally via two alternative flows:
    watsonx-ai template invoke "<PROMPT>"
    ```
 
-### Option B: Python Script (Deprecated)
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 1. **Run Python Script**:
 
@@ -175,7 +175,7 @@ You can test and debug your AI service locally via two alternative flows:
 
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
 
 ## ☁️ Deploying on IBM Cloud
 
@@ -185,7 +185,7 @@ Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-### Option A: CLI (Recommended)
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
 watsonx-ai service new
@@ -193,7 +193,7 @@ watsonx-ai service new
 
 *Config file updates automatically with `deployment_id`.*
 
-### Option B: Python Script (Deprecated)
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 ```sh
 python scripts/deploy.py
@@ -202,13 +202,13 @@ python scripts/deploy.py
 *Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
 
 ## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Option A: CLI (Recommended)
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
 watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
@@ -220,7 +220,7 @@ watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
 watsonx-ai service invoke "<PROMPT>"
 ```
 
-### Option B: Python Script (Deprecated)
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
 
@@ -236,4 +236,4 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
    ```
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -11,7 +11,7 @@
 * [Running the application locally](#-running-the-application-locally)  
 * [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
 * [Querying the deployment](#-querying-the-deployment)  
-* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
+* [Cloning template (Optional)](#-cloning-template-optional)  
 
 ## 🤔 Introduction
 
@@ -58,16 +58,49 @@ langgraph-react-agent/
 
 To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
-```sh
-pip install -U ibm-watsonx-ai-cli
-```
+1. **Install CLI**:
 
-> [!WARNING]
-> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
-> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
+   ```sh
+   pip install -U ibm-watsonx-ai-cli
+   ```
+
+2. **Download template**:
+   ```sh
+   watsonx-ai template new "base/langgraph-react-agent"
+   ```
+
+   Upon executing the above command, a prompt will appear requesting the user to specify the target directory for downloading the template. Once the template has been successfully downloaded, navigate to the designated template folder to proceed.
 
 > [!NOTE]
-> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning template (Optional)](#-cloning-template-optional)".
+
+3. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+4. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+5. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+6. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```
 
 ## ⚙️ Configuration
 
@@ -118,21 +151,13 @@ Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
-1. **Install CLI**:
+```sh
+watsonx-ai template invoke "<PROMPT>"
+```
 
-   ```sh
-   pip install ibm-watsonx-ai-cli
-   ```
-
-2. **Invoke**:
-
-   ```sh
-   watsonx-ai template invoke "<PROMPT>"
-   ```
-
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 1. **Run Python Script**:
 
@@ -145,7 +170,7 @@ You can test and debug your AI service locally via two alternative flows:
    Choose from some pre-defined questions or ask the model your own.
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## ☁️ Deploying on IBM Cloud
 
@@ -155,7 +180,7 @@ Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service new
@@ -163,7 +188,7 @@ watsonx-ai service new
 
 *Config file updates automatically with `deployment_id`.*
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 ```sh
 python scripts/deploy.py
@@ -172,13 +197,13 @@ python scripts/deploy.py
 *Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
@@ -190,7 +215,7 @@ watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
 watsonx-ai service invoke "<PROMPT>"
 ```
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
 
@@ -206,7 +231,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
    ```
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ---
 
@@ -214,7 +239,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-## 💾 Cloning and setting up the template (Optional)
+## 💾 Cloning template (Optional)
 
 1. **Clone the repo** (sparse checkout):
 
@@ -229,31 +254,3 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 > [!NOTE]
 > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/langgraph-react-agent/`  
-
-2. **Install Poetry**:
-
-   ```sh
-   pipx install --python 3.11 poetry
-   ```
-
-3. **Install the template**:
-
-    Running the below commands will install the repository in a separate virtual environment
-   
-   ```sh
-   poetry install
-   ```
-
-4. **(Optional) Activate the virtual environment**:
-
-   ```sh
-   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-   ```
-
-5. **Export PYTHONPATH**:
-
-   Adding working directory to PYTHONPATH is necessary for the next steps.
-
-   ```sh
-   export PYTHONPATH=$(pwd):${PYTHONPATH}
-   ```

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -1,10 +1,13 @@
-# A Base LangGraph LLM app template with function calling capabilities  
+# A Base LangGraph LLM app template with function calling capabilities 🚀
 
-Table of contents:  
+---
+
+## 📖 Table of Contents
 * [Introduction](#introduction)  
 * [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  
 * [Prerequisites](#prerequisites)  
 * [Cloning and setting up the template](#cloning-and-setting-up-the-template)  
+* [Configuration](#configuration)  
 * [Modifying and configuring the template](#modifying-and-configuring-the-template)  
 * [Running unit tests for the template](#running-unit-tests-for-the-template)  
 * [Running the application locally](#running-the-application-locally)  
@@ -13,98 +16,108 @@ Table of contents:
 
 ---
 
-## Introduction  
+## 🤔 Introduction
 
-This repository provides a basic template for LLM apps built using LangGraph framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].  
-An AI service is a deployable unit of code that captures the logic of your generative AI use case. For and in-depth description of the topic please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).  
+This repository provides a basic template for LLM apps built using the LangGraph framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
 
-[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.  
+An AI service is a deployable unit of code that encapsulates the logic of your generative AI use case. For an in-depth description of AI services, please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).
 
-The template builds a simple application with external tool for addressing Web Search Agent use case.  
+[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.
+
+**Highlights:**
+
+* 🚀 Easy-to-extend agent and tool modules
+* ⚙️ Configurable via `config.toml`
+* ✅ Built-in testing and CI readiness
+* 🌐 Step-by-step local and cloud deployment
 
 ---
 
-## Directory structure and file descriptions  
+## 🗂 Directory structure and file descriptions
 
 The high level structure of the repository is as follows:  
 
-langgraph-react-agent  
- ┣ src  
- ┃ ┗ langgraph_react_agent_base  
- ┃   ┣ agent.py  
- ┃   ┗ tools.py  
- ┣ schema  
- ┣ ai_service.py  
- ┣ config.toml.example  
- ┣ pyproject.toml  
+```
+langgraph-react-agent/
+├── src/
+│   └── langgraph_react_agent_base/
+│       ├── agent.py      # Core graph and agent logic
+│       └── tools.py      # Custom tool definitions
+├── schema/               # JSON schemas for requests & responses
+├── ai_service.py         # Main AI service entry point
+├── config.toml.example   # Sample settings file
+└── pyproject.toml        # Poetry configuration
+```
 
-- `langgraph-react-agent-base` folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
-- `schema` folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
-- `ai_service.py` file: Contains the function to be deployed as an AI service defining the application's logic  
-- `config.toml.example` file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case. 
+* **`langgraph-react-agent-base`** folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
+* **`schema`** folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
+* **`ai_service.py`** file: Contains the function to be deployed as an AI service defining the application's logic  
+* **`config.toml.example`**: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case. 
 
 ---
 
-## Prerequisites  
+## 🛠 Prerequisites
 
-- [Poetry](https://python-poetry.org/) package manager,  
-- [Pipx](https://github.com/pypa/pipx) due to Poetry's recommended [installation procedure](https://python-poetry.org/docs/#installation)  
-
----
-
-## Cloning and setting up the template locally  
-
-
-### Step 1: Clone the repository  
-
-In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
-
-```sh
-git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
-cd watsonx-developer-hub
-git sparse-checkout add agents/base/langgraph-react-agent
-```  
-
-Move to the directory with the agent template:
-
-```sh
-cd agents/base/langgraph-react-agent/
-```
-
-> [!NOTE]
-> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/langgraph-react-agent/`  
-
-
-### Step 2: Install poetry  
-
-```sh
-pipx install --python 3.11 poetry
-```
-
-### Step 3: Install the template    
-
-Running the below commands will install the repository in a separate virtual environment  
-
-```sh
-poetry install
-```
-
-### Step 4 (OPTIONAL): Activate the virtual environment  
-
-```sh
-source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-```
-
-### Step 5: Export PYTHONPATH  
-
-Adding working directory to PYTHONPATH is necessary for the next steps. In your terminal execute:  
-```sh
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-```
+* **Python 3.11**
+* **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
+* IBM Cloud access and permissions
 
 ---
 
-## Modifying and configuring the template  
+## 📥 Cloning and setting up the template
+
+1. **Clone the repo** (sparse checkout):
+
+   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+   
+   ```sh
+   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
+   cd watsonx-developer-hub
+   git sparse-checkout add agents/base/langgraph-react-agent
+   cd agents/base/langgraph-react-agent/
+   ```
+
+   > [!NOTE]
+   > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/langgraph-react-agent/`  
+
+2. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+3. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+4. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+5. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```
+
+---
+
+## ⚙️ Configuration
+
+1. Copy `config.toml.example` → `config.toml`.
+2. Fill in IBM Cloud credentials.
+
+---
+
+## 🎨 Modifying and configuring the template
 
 [config.toml](config.toml) file should be filled in before either deploying the template on IBM Cloud or executing it locally.  
 Possible config parameters are given in the provided file and explained using comments (when necessary).  
@@ -132,7 +145,7 @@ For more sophisticated use cases (like async tools), please refer to the [langch
 
 ---
 
-## Testing the template  
+## 🧪 Testing the template
 
 The `tests/` directory's structure resembles the repository. Adding new tests should follow this convention.  
 For exemplary purposes only the tools and some general utility functions are covered with unit tests.  
@@ -144,111 +157,105 @@ pytest -r 'fEsxX' tests/
 
 ---
 
-## Running the application locally  
+## 💻 Running the application locally
 
-It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.  
+It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.
 
-### Step 1: Fill in the `config` file  
-
-Enter the necessary credentials in the `config.toml` file.  
-
-### Step 2: Run the script for local AI service execution  
+Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-#### Flow 1: Using the `ibm-watsonx-ai-cli` package (recommended)
+### Option A: CLI (Recommended)
 
-1. **Install the CLI**  
-    ```sh
-    pip install ibm-watsonx-ai-cli
-    ```
-2. **Run CLI command with provided question**  
-    ```sh
-    watsonx-ai template invoke "<PROMPT>"
-    ```
+1. **Install CLI**:
 
-#### Flow 2: Using the Python example scripts and ask the model (deprecated)
+   ```sh
+   pip install ibm-watsonx-ai-cli
+   ```
+
+2. **Invoke**:
+
+   ```sh
+   watsonx-ai template invoke "<PROMPT>"
+   ```
+
+### Option B: Python Script (Deprecated)
+
+1. **Run Python Script**:
+
+   ```sh
+   python examples/execute_ai_service_locally.py
+   ```
+
+2. **Ask the model**:
+
+   Choose from some pre-defined questions or ask the model your own.
+
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
 
-1. **Run python script**
-    ```sh
-    python examples/execute_ai_service_locally.py
-    ```  
-
-2. **Ask the model**
-    Choose from some pre-defined questions or ask the model your own.
-
 ---
 
-## Deploying on IBM Cloud  
+## ☁️ Deploying on IBM Cloud
 
-Follow these steps to deploy the model on IBM Cloud.  
+Follow these steps to deploy the model on IBM Cloud. 
 
-### Step 1: Fill in the `config` file  
-
-Enter the necessary credentials in the `config.toml` file.  
-
-### Step 2: Run the deployment script  
+Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-#### Flow 1: Using the `ibm-watsonx-ai-cli` package (recommended)
+### Option A: CLI (Recommended)
 
-1. **Run CLI command**
-    ```sh
-    watsonx-ai service new
-    ```
+```sh
+watsonx-ai service new
+```
 
-    Upon successful completion of the deployment process, the `deployment_id` entry in the `config.toml` file will be updated with the correct deployment identifier.
+*Config file updates automatically with `deployment_id`.*
 
-#### Flow 2: Using the Python deployment script (deprecated)
+### Option B: Python Script (Deprecated)
+
+```sh
+python scripts/deploy.py
+```
+
+*Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
-
-1. **Run python script**
-    ```sh
-    python scripts/deploy.py
-    ```  
-
-Successfully completed script will print on stdout the `deployment_id` which is necessary to locally test the deployment. For further info please refer [to the next section](#querying-the-deployment)  
 
 ---
 
-## Querying the deployment  
+## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Flow 1: Using the `ibm-watsonx-ai-cli` package (recommended)
+### Option A: CLI (Recommended)
 
-1. **Run CLI command**
-    ```sh
-    watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
-    ```
+```sh
+watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
+```
 
-    If the `deployment_id` value in your `config.toml` file is already set (i.e. not None), you may omit the `--deployment-id` option and simply run:
+*If `deployment_id` is set in `config.toml`, omit the flag.*
 
-    ```sh
-    watsonx-ai service invoke "<PROMPT>"
-    ```
+```sh
+watsonx-ai service invoke "<PROMPT>"
+```
 
+### Option B: Python Script (Deprecated)
 
-### Flow 2: Using the Python example script (deprecated)
+Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
+
+1. **Initialize the deployment ID**:
+
+   Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
+   The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
+
+2. **Run the script for querying the deployment**:
+
+   ```sh
+   python examples/query_existing_deployment.py
+   ```
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
-
-Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  
-
-1. **Initialize the deployment ID**  
-
-    Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-    The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
-
-2. **Run the script for querying the deployment**  
-
-    ```sh
-    python examples/query_existing_deployment.py
-    ```   

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -1,16 +1,18 @@
 # A Base LangGraph LLM app template with function calling capabilities 🚀
 
 ## 📖 Table of Contents
-* [Introduction](#introduction)  
-* [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  
-* [Prerequisites](#prerequisites)  
-* [Cloning and setting up the template](#cloning-and-setting-up-the-template)  
-* [Configuration](#configuration)  
-* [Modifying and configuring the template](#modifying-and-configuring-the-template)  
-* [Running unit tests for the template](#running-unit-tests-for-the-template)  
-* [Running the application locally](#running-the-application-locally)  
-* [Deploying on Cloud](#deploying-on-ibm-cloud)  
-* [Inferencing the deployment](#inferencing-the-deployment)  
+* [Introduction](#-introduction)  
+* [Directory structure and file descriptions](#-directory-structure-and-file-descriptions)  
+* [Prerequisites](#-prerequisites)  
+* [Installation](#-installation)
+* [Configuration](#-configuration)  
+* [Modifying and configuring the template](#-modifying-and-configuring-the-template)  
+* [Testing the template](#-testing-the-template)  
+* [Running the application locally](#-running-the-application-locally)  
+* [Deploying on IBM Cloud](#-deploying-on-ibm-cloud)  
+* [Querying the deployment](#-querying-the-deployment)  
+* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
+
 
 ## 🤔 Introduction
 
@@ -66,7 +68,7 @@ pip install -U ibm-watsonx-ai-cli
 > To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
 
 > [!NOTE]
-> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#cloning-and-setting-up-the-template-optional)".
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
 
 ## ⚙️ Configuration
 

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -5,11 +5,11 @@
 * [Directory structure and file descriptions](#-directory-structure-and-file-descriptions)  
 * [Prerequisites](#-prerequisites)  
 * [Installation](#-installation)
-* [Configuration](#-configuration)  
+* [Configuration](#%EF%B8%8F-configuration)  
 * [Modifying and configuring the template](#-modifying-and-configuring-the-template)  
 * [Testing the template](#-testing-the-template)  
 * [Running the application locally](#-running-the-application-locally)  
-* [Deploying on IBM Cloud](#-deploying-on-ibm-cloud)  
+* [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
 * [Querying the deployment](#-querying-the-deployment)  
 * [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
@@ -199,7 +199,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 1. **Initialize the deployment ID**:
 
    Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-   The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
+   The _deployment_id_ of your deployment can be obtained from [the previous section](#%EF%B8%8F-deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
 
 2. **Run the script for querying the deployment**:
 

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -24,7 +24,6 @@ An AI service is a deployable unit of code that encapsulates the logic of your g
 
 * 🚀 Easy-to-extend agent and tool modules
 * ⚙️ Configurable via `config.toml`
-* ✅ Built-in testing and CI readiness
 * 🌐 Step-by-step local and cloud deployment
 
 ## 🗂 Directory structure and file descriptions
@@ -54,49 +53,20 @@ langgraph-react-agent/
 * **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
 * IBM Cloud access and permissions
 
-## 📥 Cloning and setting up the template
+## 📥 Installation
 
-1. **Clone the repo** (sparse checkout):
+To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
-   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
-   
-   ```sh
-   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
-   cd watsonx-developer-hub
-   git sparse-checkout add agents/base/langgraph-react-agent
-   cd agents/base/langgraph-react-agent/
-   ```
+```sh
+pip install -U ibm-watsonx-ai-cli
+```
+
+> [!WARNING]
+> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
+> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
 
 > [!NOTE]
-> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/langgraph-react-agent/`  
-
-2. **Install Poetry**:
-
-   ```sh
-   pipx install --python 3.11 poetry
-   ```
-
-3. **Install the template**:
-
-    Running the below commands will install the repository in a separate virtual environment
-   
-   ```sh
-   poetry install
-   ```
-
-4. **(Optional) Activate the virtual environment**:
-
-   ```sh
-   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-   ```
-
-5. **Export PYTHONPATH**:
-
-   Adding working directory to PYTHONPATH is necessary for the next steps.
-
-   ```sh
-   export PYTHONPATH=$(pwd):${PYTHONPATH}
-   ```
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#cloning-and-setting-up-the-template-optional)".
 
 ## ⚙️ Configuration
 
@@ -237,3 +207,53 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+---
+
+**Enjoy your coding! 🚀**
+
+---
+
+## 💾 Cloning and setting up the template (Optional)
+
+1. **Clone the repo** (sparse checkout):
+
+   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+   
+   ```sh
+   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
+   cd watsonx-developer-hub
+   git sparse-checkout add agents/base/langgraph-react-agent
+   cd agents/base/langgraph-react-agent/
+   ```
+
+> [!NOTE]
+> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/langgraph-react-agent/`  
+
+2. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+3. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+4. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+5. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -1,7 +1,5 @@
 # A Base LangGraph LLM app template with function calling capabilities 🚀
 
----
-
 ## 📖 Table of Contents
 * [Introduction](#introduction)  
 * [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -67,8 +67,8 @@ langgraph-react-agent/
    cd agents/base/langgraph-react-agent/
    ```
 
-   > [!NOTE]
-   > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/langgraph-react-agent/`  
+> [!NOTE]
+> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/langgraph-react-agent/`  
 
 2. **Install Poetry**:
 

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -11,6 +11,7 @@ Table of contents:
 * [Deploying on Cloud](#deploying-on-ibm-cloud)  
 * [Inferencing the deployment](#inferencing-the-deployment)  
 
+---
 
 ## Introduction  
 
@@ -20,6 +21,8 @@ An AI service is a deployable unit of code that captures the logic of your gener
 [^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.  
 
 The template builds a simple application with external tool for addressing Web Search Agent use case.  
+
+---
 
 ## Directory structure and file descriptions  
 
@@ -40,11 +43,14 @@ langgraph-react-agent
 - `ai_service.py` file: Contains the function to be deployed as an AI service defining the application's logic  
 - `config.toml.example` file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case. 
 
+---
+
 ## Prerequisites  
 
 - [Poetry](https://python-poetry.org/) package manager,  
 - [Pipx](https://github.com/pypa/pipx) due to Poetry's recommended [installation procedure](https://python-poetry.org/docs/#installation)  
 
+---
 
 ## Cloning and setting up the template locally  
 
@@ -96,6 +102,8 @@ Adding working directory to PYTHONPATH is necessary for the next steps. In your 
 export PYTHONPATH=$(pwd):${PYTHONPATH}
 ```
 
+---
+
 ## Modifying and configuring the template  
 
 [config.toml](config.toml) file should be filled in before either deploying the template on IBM Cloud or executing it locally.  
@@ -122,6 +130,8 @@ In order to add new tool create a new function, wrap it with the `@tool` decorat
 
 For more sophisticated use cases (like async tools), please refer to the [langchain docs](https://python.langchain.com/docs/how_to/custom_tools/#creating-tools-from-runnables).  
 
+---
+
 ## Testing the template  
 
 The `tests/` directory's structure resembles the repository. Adding new tests should follow this convention.  
@@ -131,6 +141,8 @@ Running the below command will run the complete tests suite:
 ```sh
 pytest -r 'fEsxX' tests/
 ```  
+
+---
 
 ## Running the application locally  
 
@@ -142,14 +154,33 @@ Enter the necessary credentials in the `config.toml` file.
 
 ### Step 2: Run the script for local AI service execution  
 
-```sh
-python examples/execute_ai_service_locally.py
-```  
+You can test and debug your AI service locally via two alternative flows:
 
-### Step 3: Ask the model  
+#### Flow 1: Using the `ibm-watsonx-ai-cli` package (recommended)
 
-Choose from some pre-defined questions or ask the model your own.
+1. **Install the CLI**  
+    ```sh
+    pip install ibm-watsonx-ai-cli
+    ```
+2. **Run CLI command with provided question**  
+    ```sh
+    watsonx-ai template invoke "<PROMPT>"
+    ```
 
+#### Flow 2: Using the Python example scripts and ask the model (deprecated)
+
+> [!NOTE]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
+
+1. **Run python script**
+    ```sh
+    python examples/execute_ai_service_locally.py
+    ```  
+
+2. **Ask the model**
+    Choose from some pre-defined questions or ask the model your own.
+
+---
 
 ## Deploying on IBM Cloud  
 
@@ -161,23 +192,63 @@ Enter the necessary credentials in the `config.toml` file.
 
 ### Step 2: Run the deployment script  
 
-```sh
-python scripts/deploy.py
-```  
+You can deploy your AI service to IBM Cloud via two alternative flows:
+
+#### Flow 1: Using the `ibm-watsonx-ai-cli` package (recommended)
+
+1. **Run CLI command**
+    ```sh
+    watsonx-ai service new
+    ```
+
+    Upon successful completion of the deployment process, the `deployment_id` entry in the `config.toml` file will be updated with the correct deployment identifier.
+
+#### Flow 2: Using the Python deployment script (deprecated)
+
+> [!NOTE]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
+
+1. **Run python script**
+    ```sh
+    python scripts/deploy.py
+    ```  
 
 Successfully completed script will print on stdout the `deployment_id` which is necessary to locally test the deployment. For further info please refer [to the next section](#querying-the-deployment)  
 
+---
+
 ## Querying the deployment  
+
+You can send inference requests to your deployed AI service via two alternative flows:
+
+### Flow 1: Using the `ibm-watsonx-ai-cli` package (recommended)
+
+1. **Run CLI command**
+    ```sh
+    watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
+    ```
+
+    If the `deployment_id` value in your `config.toml` file is already set (i.e. not None), you may omit the `--deployment-id` option and simply run:
+
+    ```sh
+    watsonx-ai service invoke "<PROMPT>"
+    ```
+
+
+### Flow 2: Using the Python example script (deprecated)
+
+> [!NOTE]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  
 
-### Step 1: Initialize the deployment ID  
+1. **Initialize the deployment ID**  
 
-Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
+    Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
+    The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
 
-### Step 2: Run the script for querying the deployment  
+2. **Run the script for querying the deployment**  
 
-```sh
-python examples/query_existing_deployment.py
-```   
+    ```sh
+    python examples/query_existing_deployment.py
+    ```   

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -169,7 +169,7 @@ You can test and debug your AI service locally via two alternative flows:
 
 #### Flow 2: Using the Python example scripts and ask the model (deprecated)
 
-> [!NOTE]  
+> [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
 
 1. **Run python script**
@@ -205,7 +205,7 @@ You can deploy your AI service to IBM Cloud via two alternative flows:
 
 #### Flow 2: Using the Python deployment script (deprecated)
 
-> [!NOTE]  
+> [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
 
 1. **Run python script**
@@ -237,7 +237,7 @@ You can send inference requests to your deployed AI service via two alternative 
 
 ### Flow 2: Using the Python example script (deprecated)
 
-> [!NOTE]  
+> [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -12,8 +12,6 @@
 * [Deploying on Cloud](#deploying-on-ibm-cloud)  
 * [Inferencing the deployment](#inferencing-the-deployment)  
 
----
-
 ## 🤔 Introduction
 
 This repository provides a basic template for LLM apps built using the LangGraph framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
@@ -28,8 +26,6 @@ An AI service is a deployable unit of code that encapsulates the logic of your g
 * ⚙️ Configurable via `config.toml`
 * ✅ Built-in testing and CI readiness
 * 🌐 Step-by-step local and cloud deployment
-
----
 
 ## 🗂 Directory structure and file descriptions
 
@@ -52,15 +48,11 @@ langgraph-react-agent/
 * **`ai_service.py`** file: Contains the function to be deployed as an AI service defining the application's logic  
 * **`config.toml.example`**: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case. 
 
----
-
 ## 🛠 Prerequisites
 
 * **Python 3.11**
 * **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
 * IBM Cloud access and permissions
-
----
 
 ## 📥 Cloning and setting up the template
 
@@ -106,14 +98,10 @@ langgraph-react-agent/
    export PYTHONPATH=$(pwd):${PYTHONPATH}
    ```
 
----
-
 ## ⚙️ Configuration
 
 1. Copy `config.toml.example` → `config.toml`.
 2. Fill in IBM Cloud credentials.
-
----
 
 ## 🎨 Modifying and configuring the template
 
@@ -141,8 +129,6 @@ In order to add new tool create a new function, wrap it with the `@tool` decorat
 
 For more sophisticated use cases (like async tools), please refer to the [langchain docs](https://python.langchain.com/docs/how_to/custom_tools/#creating-tools-from-runnables).  
 
----
-
 ## 🧪 Testing the template
 
 The `tests/` directory's structure resembles the repository. Adding new tests should follow this convention.  
@@ -151,9 +137,7 @@ For exemplary purposes only the tools and some general utility functions are cov
 Running the below command will run the complete tests suite:
 ```sh
 pytest -r 'fEsxX' tests/
-```  
-
----
+```
 
 ## 💻 Running the application locally
 
@@ -193,8 +177,6 @@ You can test and debug your AI service locally via two alternative flows:
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
 
----
-
 ## ☁️ Deploying on IBM Cloud
 
 Follow these steps to deploy the model on IBM Cloud. 
@@ -221,8 +203,6 @@ python scripts/deploy.py
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Flow 1 as soon as possible.
-
----
 
 ## 🔍 Querying the deployment
 

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -212,7 +212,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-##  **Enjoy your coding! 🚀**
+**Enjoy your coding! 🚀**
 
 ---
 

--- a/agents/base/langgraph-react-agent/README.md
+++ b/agents/base/langgraph-react-agent/README.md
@@ -212,7 +212,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-**Enjoy your coding! 🚀**
+##  **Enjoy your coding! 🚀**
 
 ---
 

--- a/agents/base/llamaindex-websearch-agent/README.md
+++ b/agents/base/llamaindex-websearch-agent/README.md
@@ -60,16 +60,49 @@ llamaindex-websearch-agent /
 
 To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
 
-```sh
-pip install -U ibm-watsonx-ai-cli
-```
+1. **Install CLI**:
 
-> [!WARNING]
-> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
-> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
+   ```sh
+   pip install -U ibm-watsonx-ai-cli
+   ```
+
+2. **Download template**:
+   ```sh
+   watsonx-ai template new "base/llamaindex-websearch-agent"
+   ```
+
+   Upon executing the above command, a prompt will appear requesting the user to specify the target directory for downloading the template. Once the template has been successfully downloaded, navigate to the designated template folder to proceed.
 
 > [!NOTE]
-> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning template (Optional)](#-cloning-template-optional)".
+
+3. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+4. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+5. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+6. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```
 
 ## ⚙️ Configuration
 
@@ -131,21 +164,13 @@ Ensure `config.toml` is configured.
 
 You can test and debug your AI service locally via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
-1. **Install CLI**:
+```sh
+watsonx-ai template invoke "<PROMPT>"
+```
 
-   ```sh
-   pip install ibm-watsonx-ai-cli
-   ```
-
-2. **Invoke**:
-
-   ```sh
-   watsonx-ai template invoke "<PROMPT>"
-   ```
-
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 1. **Run Python Script**:
 
@@ -158,7 +183,7 @@ You can test and debug your AI service locally via two alternative flows:
    Choose from some pre-defined questions or ask the model your own.
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## ☁️ Deploying on IBM Cloud
 
@@ -168,7 +193,7 @@ Ensure `config.toml` is configured.
 
 You can deploy your AI service to IBM Cloud via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service new
@@ -176,7 +201,7 @@ watsonx-ai service new
 
 *Config file updates automatically with `deployment_id`.*
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 ```sh
 python scripts/deploy.py
@@ -185,13 +210,13 @@ python scripts/deploy.py
 *Script prints `deployment_id`; update `config.toml`.*
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ## 🔍 Querying the deployment
 
 You can send inference requests to your deployed AI service via two alternative flows:
 
-### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+### ✅ Recommended flow: CLI
 
 ```sh
 watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
@@ -203,7 +228,7 @@ watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
 watsonx-ai service invoke "<PROMPT>"
 ```
 
-### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+### ⚠️ Alternative flow: Python Script (Deprecated)
 
 Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
 
@@ -219,7 +244,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
    ```
 
 > [!WARNING]  
-> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+> This flow is deprecated and will be removed in a future release. Please migrate to recommended flow as soon as possible.
 
 ---
 
@@ -227,7 +252,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-## 💾 Cloning and setting up the template (Optional)
+## 💾 Cloning template (Optional)
 
 1. **Clone the repo** (sparse checkout):
 
@@ -242,31 +267,3 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 > [!NOTE]
 > From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/llamaindex-websearch-agent`  
-
-2. **Install Poetry**:
-
-   ```sh
-   pipx install --python 3.11 poetry
-   ```
-
-3. **Install the template**:
-
-    Running the below commands will install the repository in a separate virtual environment
-   
-   ```sh
-   poetry install
-   ```
-
-4. **(Optional) Activate the virtual environment**:
-
-   ```sh
-   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-   ```
-
-5. **Export PYTHONPATH**:
-
-   Adding working directory to PYTHONPATH is necessary for the next steps.
-
-   ```sh
-   export PYTHONPATH=$(pwd):${PYTHONPATH}
-   ```

--- a/agents/base/llamaindex-websearch-agent/README.md
+++ b/agents/base/llamaindex-websearch-agent/README.md
@@ -14,8 +14,7 @@
 * [Querying the deployment](#-querying-the-deployment)  
 * [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
-
-## Introduction  
+## 🤔 Introduction
 
 This repository provides a basic template for LLM apps built using LlamaIndex framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
 
@@ -157,7 +156,6 @@ You can test and debug your AI service locally via two alternative flows:
 2. **Ask the model**:
 
    Choose from some pre-defined questions or ask the model your own.
-
 
 > [!WARNING]  
 > This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.

--- a/agents/base/llamaindex-websearch-agent/README.md
+++ b/agents/base/llamaindex-websearch-agent/README.md
@@ -225,7 +225,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-## **Enjoy your coding! 🚀**
+**Enjoy your coding! 🚀**
 
 ---
 

--- a/agents/base/llamaindex-websearch-agent/README.md
+++ b/agents/base/llamaindex-websearch-agent/README.md
@@ -1,102 +1,83 @@
-# A LlamaIndex Workflow LLM app template with function calling capabilities
+# A LlamaIndex Workflow LLM app template with function calling capabilities 🚀
 
-Table of contents:  
-* [Introduction](#introduction)  
-* [Directory structure and file descriptions](#directory-structure-and-file-descriptions)  
-* [Prerequisites](#prerequisites)  
-* [Cloning and setting up the template](#cloning-and-setting-up-the-template)  
-* [Modifying and configuring the template](#modifying-and-configuring-the-template)  
-* [Running unit tests for the template](#running-unit-tests-for-the-template)  
-* [Running the application locally](#running-the-application-locally)  
-* [Deploying on Cloud](#deploying-on-ibm-cloud)  
-* [Inferencing the deployment](#inferencing-the-deployment)  
+## 📖 Table of Contents
+* [Introduction](#-introduction)  
+* [Directory structure and file descriptions](#-directory-structure-and-file-descriptions)  
+* [Prerequisites](#-prerequisites)  
+* [Installation](#-installation)
+* [Configuration](#%EF%B8%8F-configuration)  
+* [Modifying and configuring the template](#-modifying-and-configuring-the-template)  
+* [Visualizing a workflow](#-visualizing-a-workflow)  
+* [Testing the template](#-testing-the-template)  
+* [Running the application locally](#-running-the-application-locally)  
+* [Deploying on IBM Cloud](#%EF%B8%8F-deploying-on-ibm-cloud)  
+* [Querying the deployment](#-querying-the-deployment)  
+* [Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)  
 
 
 ## Introduction  
 
-This repository provides a basic template for LLM apps built using LlamaIndex framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].  
-An AI service is a deployable unit of code that captures the logic of your generative AI use case. For and in-depth description of the topic please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).  
+This repository provides a basic template for LLM apps built using LlamaIndex framework. It also makes it easy to deploy them as an AI service as part of IBM watsonx.ai for IBM Cloud[^1].
 
-[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.  
+An AI service is a deployable unit of code that encapsulates the logic of your generative AI use case. For an in-depth description of AI services, please refer to the [IBM watsonx.ai documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ai-services-templates.html?context=wx&audience=wdp).
 
-The template builds a simple application with external tool for addressing Dummy Web Search use case.   
+[^1]: _IBM watsonx.ai for IBM Cloud_ is a full and proper name of the component we're using in this template and only a part of the whole suite of products offered in the SaaS model within IBM Cloud environment. Throughout this README, for the sake of simplicity, we'll be calling it just an **IBM Cloud**.
 
-## Directory structure and file descriptions  
+**Highlights:**
+
+* 🚀 Easy-to-extend agent and tool modules
+* ⚙️ Configurable via `config.toml`
+* 🌐 Step-by-step local and cloud deployment
+
+## 🗂 Directory structure and file descriptions
 
 The high level structure of the repository is as follows:  
 
-llamaindex-websearch-agent  
- ┣ src  
- ┃ ┗ llama_index_workflow_agent_base  
- ┃   ┣ agent.py  
- ┃   ┣ tools.py  
- ┃   ┗ workflow.py  
- ┣ schema  
- ┣ ai_service.py 
- ┣ config.toml.example  
- ┗ pyproject.toml  
-
-- `llama_index_workflow_agent_base ` folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
-- `schema` folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
-- `ai_service.py` file: Contains the function to be deployed as an AI service defining the application's logic  
-- `config.toml.example` file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case.
-
-## Prerequisites  
-
-- [Poetry](https://python-poetry.org/) package manager,  
-- [Pipx](https://github.com/pypa/pipx) due to Poetry's recommended [installation procedure](https://python-poetry.org/docs/#installation)  
-
-## Cloning and setting up the template locally  
-
-
-### Step 1: Clone the repository  
-
-In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
-
-```sh
-git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
-cd watsonx-developer-hub
-git sparse-checkout add agents/base/llamaindex-websearch-agent
-```  
-
-Move to the directory with the agent template:
-
-```sh
-cd agents/base/llamaindex-websearch-agent/
 ```
+llamaindex-websearch-agent /
+├── src/
+│   └── llama_index_workflow_agent_base/
+│       ├── agent.py      # Core graph and agent logic
+│       ├── tools.py      # Custom tool definitions
+│       └── workflow.py   # Custom workflow definitions
+├── schema/               # JSON schemas for requests & responses
+├── ai_service.py         # Main AI service entry point
+├── config.toml.example   # Sample settings file
+└── pyproject.toml        # Poetry configuration
+```
+
+* **`llama_index_workflow_agent_base`** folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  
+* **`schema`** folder: Contains request and response schemas for the `/ai_service` endpoint queries.  
+* **`ai_service.py`** file: Contains the function to be deployed as an AI service defining the application's logic  
+* **`config.toml.example`** file: A configuration file with placeholders that stores the deployment metadata. After downloading the template repository, copy the contents of the `config.toml.example` file to the `config.toml` file and fill in the required fields. `config.toml` file can also be used to tweak the model for your use case.
+
+## 🛠 Prerequisites
+
+* **Python 3.11**
+* **[Poetry](https://python-poetry.org/)** package manager (install via [pipx](https://github.com/pypa/pipx))
+* IBM Cloud access and permissions
+
+## 📥 Installation
+
+To begin working with this template using the Command Line Interface (CLI), please ensure that the IBM watsonx AI CLI tool is installed on your system. You can install or upgrade it using the following command:
+
+```sh
+pip install -U ibm-watsonx-ai-cli
+```
+
+> [!WARNING]
+> The `ibm_watsonx_ai_cli` package requires `poetry` to be installed.
+> To install Poetry, follow the instructions on the [Poetry installation page](https://python-poetry.org/docs/#installation).
 
 > [!NOTE]
-> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/llamaindex-websearch-agent`  
+> Alternatively, it is possible to set up the template using a different method. For detailed instructions, please refer to the section "[Cloning and setting up the template (Optional)](#-cloning-and-setting-up-the-template-optional)".
 
+## ⚙️ Configuration
 
-### Step 2: Install poetry  
+1. Copy `config.toml.example` → `config.toml`.
+2. Fill in IBM Cloud credentials.
 
-```sh
-pipx install --python 3.11 poetry
-```
-
-### Step 3: Install the template    
-
-Running the below commands will install the repository in a separate virtual environment  
-
-```sh
-poetry install
-```
-
-### Step 4 (OPTIONAL): Activate the virtual environment  
-
-```sh
-source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
-```
-
-### Step 5: Export PYTHONPATH  
-
-Adding working directory to PYTHONPATH is necessary for the next steps. In your terminal execute:  
-```sh
-export PYTHONPATH=$(pwd):${PYTHONPATH}
-```
-
-## Modifying and configuring the template  
+## 🎨 Modifying and configuring the template
 
 [config.toml](config.toml) file should be filled in before either deploying the template on IBM Cloud or executing it locally.  
 Possible config parameters are given in the provided file and explained using comments (when necessary).  
@@ -121,7 +102,7 @@ For a detailed breakdown of the ai-service's implementation please refer the [IB
 [tools.py](src/llama_index_workflow_agent_base/tools.py) file stores the definition for tools enhancing the chat model's capabilities.  
 In order to add new tool create a new function and add to the `TOOLS` list in the `extensions` module's [__init__.py](src/llama_index_workflow_agent_base/__init__.py)
 
-## Visualizing a workflow  
+## 📊 Visualizing a workflow  
 
 One of the key features of workflows is the built-in visualization capability. To generate a visual representation of a workflow, execute the following command:
 
@@ -133,7 +114,7 @@ This command produces a graphical representation of the workflow, providing a cl
 
 ![Workflow visualization](assets/workflow_visualization.png)
 
-## Testing the template  
+## 🧪 Testing the template
 
 The `tests/` directory's structure resembles the repository. Adding new tests should follow this convention.  
 For exemplary purposes only the tools and some general utility functions are covered with unit tests.  
@@ -143,52 +124,151 @@ Running the below command will run the complete tests suite:
 pytest -r 'fEsxX' tests/
 ```  
 
-## Running the application locally  
+## 💻 Running the application locally
 
-It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.  
+It is possible to run (or even debug) the ai-service locally, however it still requires creating the connection to the IBM Cloud.
 
-### Step 1: Fill in the `config` file  
+Ensure `config.toml` is configured.
 
-Enter the necessary credentials in the `config.toml` file.  
+You can test and debug your AI service locally via two alternative flows:
 
-### Step 2: Run the script for local AI service execution  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
+
+1. **Install CLI**:
+
+   ```sh
+   pip install ibm-watsonx-ai-cli
+   ```
+
+2. **Invoke**:
+
+   ```sh
+   watsonx-ai template invoke "<PROMPT>"
+   ```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+1. **Run Python Script**:
+
+   ```sh
+   python examples/execute_ai_service_locally.py
+   ```
+
+2. **Ask the model**:
+
+   Choose from some pre-defined questions or ask the model your own.
+
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+## ☁️ Deploying on IBM Cloud
+
+Follow these steps to deploy the model on IBM Cloud. 
+
+Ensure `config.toml` is configured.
+
+You can deploy your AI service to IBM Cloud via two alternative flows:
+
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/execute_ai_service_locally.py
-```  
+watsonx-ai service new
+```
 
-### Step 3: Ask the model  
+*Config file updates automatically with `deployment_id`.*
 
-Choose from some pre-defined questions or ask the model your own.
-
-
-## Deploying on IBM Cloud  
-
-Follow these steps to deploy the model on IBM Cloud.  
-
-### Step 1: Fill in the `config` file  
-
-Enter the necessary credentials in the `config.toml` file.  
-
-### Step 2: Run the deployment script  
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
 
 ```sh
 python scripts/deploy.py
-```  
+```
 
-Successfully completed script will print on stdout the `deployment_id` which is necessary to locally test the deployment. For further info please refer [to the next section](#querying-the-deployment)  
+*Script prints `deployment_id`; update `config.toml`.*
 
-## Querying the deployment  
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
 
-Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.  
+## 🔍 Querying the deployment
 
-### Step 1: Initialize the deployment ID  
+You can send inference requests to your deployed AI service via two alternative flows:
 
-Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
-The _deployment_id_ of your deployment can be obtained from [the previous section](#deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py)  
-
-### Step 2: Run the script for querying the deployment  
+### Option A: CLI (<span style="color: #28a745">Recommended</span>)
 
 ```sh
-python examples/query_existing_deployment.py
-```   
+watsonx-ai service invoke --deployment_id "<DEPLOYMENT_ID>" "<PROMPT>"
+```
+
+*If `deployment_id` is set in `config.toml`, omit the flag.*
+
+```sh
+watsonx-ai service invoke "<PROMPT>"
+```
+
+### Option B: Python Script (<span style="color: #dc3545">Deprecated</span>)
+
+Follow these steps to inference your deployment. The [query_existing_deployment.py](examples/query_existing_deployment.py) file shows how to test the existing deployment using `watsonx.ai` library.
+
+1. **Initialize the deployment ID**:
+
+   Initialize the `deployment_id` variable in the [query_existing_deployment.py](examples/query_existing_deployment.py) file.  
+   The _deployment_id_ of your deployment can be obtained from [the previous section](#%EF%B8%8F-deploying-on-ibm-cloud) by running [scripts/deploy.sh](scripts/deploy.py) 
+
+2. **Run the script for querying the deployment**:
+
+   ```sh
+   python examples/query_existing_deployment.py
+   ```
+
+> [!WARNING]  
+> This flow is deprecated and will be removed in a future release. Please migrate to Option A as soon as possible.
+
+---
+
+**Enjoy your coding! 🚀**
+
+---
+
+## 💾 Cloning and setting up the template (Optional)
+
+1. **Clone the repo** (sparse checkout):
+
+   In order not to clone the whole `IBM/watsonx-developer-hub` repository we'll use git's shallow and sparse cloning feature to checkout only the template's directory:  
+   
+   ```sh
+   git clone --no-tags --depth 1 --single-branch --filter=tree:0 --sparse https://github.com/IBM/watsonx-developer-hub.git
+   cd watsonx-developer-hub
+   git sparse-checkout add agents/base/llamaindex-websearch-agent
+   cd agents/base/llamaindex-websearch-agent/
+   ```
+
+> [!NOTE]
+> From now on it'll be considered that the working directory is `watsonx-developer-hub/agents/base/llamaindex-websearch-agent`  
+
+2. **Install Poetry**:
+
+   ```sh
+   pipx install --python 3.11 poetry
+   ```
+
+3. **Install the template**:
+
+    Running the below commands will install the repository in a separate virtual environment
+   
+   ```sh
+   poetry install
+   ```
+
+4. **(Optional) Activate the virtual environment**:
+
+   ```sh
+   source $(poetry -q env use 3.11 && poetry env info --path)/bin/activate
+   ```
+
+5. **Export PYTHONPATH**:
+
+   Adding working directory to PYTHONPATH is necessary for the next steps.
+
+   ```sh
+   export PYTHONPATH=$(pwd):${PYTHONPATH}
+   ```

--- a/agents/base/llamaindex-websearch-agent/README.md
+++ b/agents/base/llamaindex-websearch-agent/README.md
@@ -225,7 +225,7 @@ Follow these steps to inference your deployment. The [query_existing_deployment.
 
 ---
 
-**Enjoy your coding! 🚀**
+## **Enjoy your coding! 🚀**
 
 ---
 

--- a/agents/base/llamaindex-websearch-agent/README.md
+++ b/agents/base/llamaindex-websearch-agent/README.md
@@ -37,13 +37,13 @@ The high level structure of the repository is as follows:
 llamaindex-websearch-agent /
 ├── src/
 │   └── llama_index_workflow_agent_base/
-│       ├── agent.py      # Core graph and agent logic
-│       ├── tools.py      # Custom tool definitions
-│       └── workflow.py   # Custom workflow definitions
-├── schema/               # JSON schemas for requests & responses
-├── ai_service.py         # Main AI service entry point
-├── config.toml.example   # Sample settings file
-└── pyproject.toml        # Poetry configuration
+│       ├── agent.py
+│       ├── tools.py
+│       └── workflow.py
+├── schema/
+├── ai_service.py
+├── config.toml.example
+└── pyproject.toml
 ```
 
 * **`llama_index_workflow_agent_base`** folder: Contains auxiliary files used by the deployed function. They provide various framework specific definitions and extensions. This folder is packaged and sent to IBM Cloud during deployment as a [package extension](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-create-custom-software-spec.html?context=wx&audience=wdp#custom-wml).  


### PR DESCRIPTION
Update base template's README to use ibm-watsonx-ai CLI instead of Python scripts

Langgraph base template preview -> [here](https://github.com/IBM/watsonx-developer-hub/blob/dev-48598-update-base-README-to-use-CLI-instead-of-script/agents/base/langgraph-react-agent/README.md)