### PR TITLE
fix: change model-id in `langgraph-react-agent` and update benchmarking data

### DIFF
--- a/agents/base/langgraph-react-agent/benchmarking_data/benchmarking_data.jsonl
+++ b/agents/base/langgraph-react-agent/benchmarking_data/benchmarking_data.jsonl
@@ -1,3 +1,3 @@
-{ "id": "1", "input": "Hi! How are you?", "ground_truth": "Hello! I'm doing well, thank you for asking. How can I assist you today?" } 
+{ "id": "1", "input": "Hi! How are you?", "ground_truth": "I'm an artificial intelligence and don't have feelings, but I'm here to help you with any information you need. How can I assist you today?" }
 { "id": "2", "input": "Search for IBM.", "ground_truth": "Here are the results I found:\n\n- IBM watsonx.ai" }
-{ "id": "3", "input": "What are Granite models?", "ground_truth": "Granite models are a type of large language model developed by IBM. They are designed to understand and generate human-like text based on the input they receive. These models are trained on a large amount of text data and can be used for a variety of tasks, such as answering questions, generating text, and even writing code." }
+{ "id": "3", "input": "What are Granite models?", "ground_truth": "According to the web search, Granite models are part of IBM watsonx.ai. They are designed for foundation models, allowing users to customize and deploy them for their specific needs." }

--- a/agents/base/langgraph-react-agent/config.toml.example
+++ b/agents/base/langgraph-react-agent/config.toml.example
@@ -11,7 +11,7 @@
 [deployment.online.parameters]
 # during creation of deployment additional parameters can be provided inside `ONLINE` object for further referencing
 # please refer to the API docs: https://cloud.ibm.com/apidocs/machine-learning-cp#deployments-create
-  model_id = "mistralai/mistral-large"  # underlying model of WatsonxChat
+  model_id = "ibm/granite-3-3-8b-instruct"  # underlying model of WatsonxChat
   url = ""  # should follow the format: `https://{REGION}.ml.cloud.ibm.com`
 
 [deployment.software_specification]


### PR DESCRIPTION
Changed `model-id` in `langgraph-react-agent/config.toml.example` to `ibm/granite-3-3-8b-instruct` and updated `benchmarking_data.jsonl`