### PR TITLE
chore: Added missing dependencies to BeeAI templates

### DIFF
--- a/agents/base/beeai-framework-requirement-agent/CHANGES.rst
+++ b/agents/base/beeai-framework-requirement-agent/CHANGES.rst
@@ -1,3 +1,8 @@
+Version 0.1.2
+-------------
+
+Added ``fastapi`` and ``orjson`` to dependencies.
+
 Version 0.1.1
 -------------
 

--- a/agents/base/beeai-framework-requirement-agent/pyproject.toml
+++ b/agents/base/beeai-framework-requirement-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beeai_framework_requirement_agent_base"
-version = "0.1.1"
+version = "0.1.2"
 description = "A template for a beeai-framework LLM app deployable on IBM Cloud as an ai_service."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/agents/base/beeai-framework-requirement-agent/pyproject.toml
+++ b/agents/base/beeai-framework-requirement-agent/pyproject.toml
@@ -14,6 +14,8 @@ python = ">=3.11,<3.14"
 beeai-framework = {extras = ["duckduckgo"], version = "^0.1.49"}
 litellm = "^1.81.1"
 pydantic = "^2.11.9"
+fastapi = "^0.139.2"
+orjson = "^3.11.9"
 
 [tool.poetry.group.dev]
 optional = true

--- a/agents/base/beeai-framework-workflow/CHANGES.rst
+++ b/agents/base/beeai-framework-workflow/CHANGES.rst
@@ -1,3 +1,8 @@
+Version 0.1.2
+-------------
+
+Added ``fastapi`` and ``orjson`` to dependencies.
+
 Version 0.1.1
 -------------
 

--- a/agents/base/beeai-framework-workflow/pyproject.toml
+++ b/agents/base/beeai-framework-workflow/pyproject.toml
@@ -14,6 +14,8 @@ python = ">=3.11,<3.14"
 beeai-framework = {extras = ["duckduckgo"], version = "^0.1.49"}
 litellm = "^1.81.1"
 pydantic = "^2.11.9"
+fastapi = "^0.139.2"
+orjson = "^3.11.9"
 
 [tool.poetry.group.dev]
 optional = true

--- a/agents/base/beeai-framework-workflow/pyproject.toml
+++ b/agents/base/beeai-framework-workflow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beeai_framework_workflow_base"
-version = "0.1.1"
+version = "0.1.2"
 description = "A template for a beeai-framework LLM app deployable on IBM Cloud as an ai_service."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"


### PR DESCRIPTION
During the automatically scheduled [test run](https://github.com/IBM/watsonx-developer-hub/actions/runs/29186937356/job/86634668577) it was noticed that the two BeeAI tests are failing with `ModuleNotFoundError: No module named 'fastapi'`. This error could also be reproduced locally and stopped appearing after these updates.