### PR TITLE
chore: Update mcp-orchestrate-autoai-template-generic template mcp server dependencies

### DIFF
--- a/agents/community/mcp-autoai-template/requirements.txt
+++ b/agents/community/mcp-autoai-template/requirements.txt
@@ -1,6 +1,6 @@
-langchain-ibm
-langchain
-langgraph
-python-dotenv
-mcp
-langchain_mcp_adapters
+langchain-ibm<2.0.0
+langchain<2.0.0
+langgraph<2.0.0
+python-dotenv<2.0.0
+mcp>=1.1.0,<2.0.0
+langchain_mcp_adapters<1.0.0

--- a/agents/mcp/mcp-orchestrate-autoai-template-generic/mcp_server/requirements.txt
+++ b/agents/mcp/mcp-orchestrate-autoai-template-generic/mcp_server/requirements.txt
@@ -2,7 +2,7 @@
 # This file MUST reside inside package_root (./mcp_server), because only that
 # folder is packaged during `orchestrate toolkits import`.
 
-mcp
-ibm-watsonx-ai
-pydantic
-python-dotenv
+mcp>=1.1.0,<2.0.0
+ibm-watsonx-ai<2.0.0
+pydantic<3.0.0
+python-dotenv<2.0.0

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -207,7 +207,7 @@ class TestOrchestrateMCPAutoAITemplate:
     # Test
     # ---------------------------------------------------------------------------
 
-    def test_orchestrate_mcp_autoai_template(
+    def test_orchestrate_mcp_autoai_template_generic(
         self,
         test_venv_path: Path,
         tmp_dir: str,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -207,7 +207,7 @@ class TestOrchestrateMCPAutoAITemplate:
     # Test
     # ---------------------------------------------------------------------------
 
-    def test_orchestrate_mcp_autoai_template_generic(
+    def test_mcp_orchestrate_autoai_template_generic(
         self,
         test_venv_path: Path,
         tmp_dir: str,


### PR DESCRIPTION
Issue: The release of `mcp` v2 introduces breaking changes. To maintain compatibility, the maximum allowed version of the `mcp` package must be constrained to versions earlier than v2.